### PR TITLE
Issue#53 - Changes to allow 115200 baud rate to be set for USB link.

### DIFF
--- a/DroidPlanner/res/values/strings.xml
+++ b/DroidPlanner/res/values/strings.xml
@@ -65,5 +65,9 @@
         <item >Normal</item>
         <item >Terrain</item>
     </string-array>
+    <string-array name="TelemetryBaudTypes">
+        <item name="57600">57600</item>
+        <item name="115200">115200</item>
+    </string-array>
     
 </resources>

--- a/DroidPlanner/res/xml/preferences.xml
+++ b/DroidPlanner/res/xml/preferences.xml
@@ -11,7 +11,13 @@
             android:key="pref_connection_type"
             android:summary="Which link to use to connect to the drone"
             android:title="Telemetry Connection Type" />
-
+        <ListPreference
+            android:defaultValue="57600"
+            android:entries="@array/TelemetryBaudTypes"
+            android:entryValues="@array/TelemetryBaudTypes"
+            android:key="pref_baud_type"
+            android:summary="Baud Rate of the USB Telementry Link"
+            android:title="Telemetry link speed" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="pref_mavlink_log_enabled"

--- a/DroidPlanner/src/com/droidplanner/connection/UsbConnection.java
+++ b/DroidPlanner/src/com/droidplanner/connection/UsbConnection.java
@@ -11,7 +11,7 @@ import com.ftdi.j2xx.D2xxManager;
 import com.ftdi.j2xx.FT_Device;
 
 public class UsbConnection extends MAVLinkConnection {
-	private static final int BAUD_RATE = 57600;
+	private static int baud_rate = 57600;
 	private static final byte LATENCY_TIMER = 16;
 	
 	private FT_Device ftDev;
@@ -48,7 +48,12 @@ public class UsbConnection extends MAVLinkConnection {
 	}
 	
 	@Override
-	protected void getPreferences(SharedPreferences prefs) {		
+	protected void getPreferences(SharedPreferences prefs) {
+		String baud_type = prefs.getString("pref_baud_type", "");
+		if (baud_type.equals("57600"))
+			baud_rate = 57600;
+		else 
+			baud_rate = 115200;	
 	}
 	
 	private void openCOM() throws IOException {
@@ -72,9 +77,9 @@ public class UsbConnection extends MAVLinkConnection {
 			Log.d("USB", "COM close");
 			throw new IOException();
 		}
-		
+		Log.d("USB", "Opening using Baud rate " + baud_rate);		
 		ftDev.setBitMode((byte) 0, D2xxManager.FT_BITMODE_RESET);
-		ftDev.setBaudRate(BAUD_RATE);
+		ftDev.setBaudRate(baud_rate);
 		ftDev.setDataCharacteristics(D2xxManager.FT_DATA_BITS_8,
 				D2xxManager.FT_STOP_BITS_1, D2xxManager.FT_PARITY_NONE);
 		ftDev.setFlowControl(D2xxManager.FT_FLOW_NONE, (byte) 0x00, (byte) 0x00);


### PR DESCRIPTION
As discussed here are some siple changes to add a preference for setting 57600 or 112500. (defaults to 57600)
After setting is changed it will be used when next Connect is done.
Tested on Aus Slider and it works OK.
Baud of 115200 allows connection to APM (V1 ONLY) with USB cable (instead of 3DR radio / wireless type connection)
