### PR TITLE
Fix for the Offline Maps

### DIFF
--- a/DroidPlanner/src/com/droidplanner/fragments/OfflineMapFragment.java
+++ b/DroidPlanner/src/com/droidplanner/fragments/OfflineMapFragment.java
@@ -85,6 +85,7 @@ public class OfflineMapFragment extends MapFragment {
 	}
 
 	private void setupOfflineMapOverlay() {
+		clearTileCache();
 		GoogleMap mMap = getMap();
 		mMap.setMapType(GoogleMap.MAP_TYPE_NONE);
 		mMap.addTileOverlay(new TileOverlayOptions()


### PR DESCRIPTION
Well, this is another try to fix off-line Maps issue.

My theory for this issue is based on the analisys of the PlanningmapFragment class, mainly at the "update" function called by the PlanningActivity class as soon as we select the Planning screen at the app.

The first thing this function do is clear all map using mMap.clear() and right after it rebuilds the home and waypoints. I couldn't find where the new map is requested again with the function onCreateView(). 

In the option "online maps", the GoogleMap class apparently handle this issue better, showing the map in the layer bellow the markers yet them had been created before map. In the option "off-line maps" I presume which the tiles overlay is put in a layer above the waypoints and somehow they are not shown. This can be confirmed when we come back to the Flight Data screen and observes that the waypoints are not shown at map, but if you zoom map you can quickly see them bellow, before the map was updated and overlayed on them.

For this reason I propose clean tiles cache at this class and call maps again in "update" function at the PlanningmapFragment class just after the mMap.clear() calling.

Hope this solve the problem.
