### PR TITLE
Fix for issue #243 and #244, Waypoint numbering issue

### DIFF
--- a/DroidPlanner/src/com/droidplanner/drone/variables/Mission.java
+++ b/DroidPlanner/src/com/droidplanner/drone/variables/Mission.java
@@ -75,7 +75,12 @@ public class Mission extends DroneVariable {
 	}
 
 	public void addWaypoints(List<waypoint> points) {
-		waypoints.addAll(points);
+		
+		//Loop through every wp and add it to the wp list
+		for (waypoint wp : points) {
+			addWaypoint(wp);
+		}
+//		waypoints.addAll(points);
 	}
 
 	public void addWaypointsWithDefaultAltitude(List<LatLng> coords) {

--- a/DroidPlanner/src/com/droidplanner/fragments/markers/PolygonMarker.java
+++ b/DroidPlanner/src/com/droidplanner/fragments/markers/PolygonMarker.java
@@ -11,7 +11,7 @@ public class PolygonMarker {
 		return new MarkerOptions()
 				.position(wp.coord)
 				.draggable(true)
-				.title("Poly" + Integer.toString(0))
+				.title("Poly")
 				// TODO fix constant
 				.icon(BitmapDescriptorFactory
 						.defaultMarker(BitmapDescriptorFactory.HUE_BLUE));
@@ -19,7 +19,7 @@ public class PolygonMarker {
 
 	public static void update(Marker marker, PolygonPoint wp) {
 		marker.setPosition(wp.coord);
-		marker.setTitle("Poly" + Integer.toString(0));// TODO fix constant
+		marker.setTitle("Poly");// TODO fix constant
 		marker.setIcon(BitmapDescriptorFactory
 				.defaultMarker(BitmapDescriptorFactory.HUE_BLUE));
 	}


### PR DESCRIPTION
When waypoints where generated by a polygon they did not received the
right numbering. Due to this the waypoints could not be uploaded to the
APM. This also removes the constant "0" from the polys title.
