### PR TITLE
MissionList: Reduce the chance of unintentionally deleting waypoints...

### DIFF
--- a/TouchListView/src/com/mobeta/android/dslv/DragSortController.java
+++ b/TouchListView/src/com/mobeta/android/dslv/DragSortController.java
@@ -387,11 +387,16 @@ public class DragSortController extends SimpleFloatViewManager implements View.O
 
         if (mCanDrag && !mDragging && (mHitPos != MISS || mFlingHitPos != MISS)) {
             if (mHitPos != MISS) {
-                if (mDragInitMode == ON_DRAG && Math.abs(y2 - y1) > mTouchSlop && mSortEnabled) {
-                    startDrag(mHitPos, deltaX, deltaY);
-                }
-                else if (mDragInitMode != ON_DOWN && Math.abs(x2 - x1) > mTouchSlop && mRemoveEnabled)
-                {
+            	if(Math.abs(y2 - y1) > mTouchSlop) {
+	                if (mDragInitMode == ON_DRAG && mSortEnabled) {
+	                    startDrag(mHitPos, deltaX, deltaY);
+	                }
+	                else {
+	                	// started scrolling - block sorting/removing
+	                	mCanDrag = false;
+	                }
+            	}
+                else if (mDragInitMode != ON_DOWN && Math.abs(x2 - x1) > mTouchSlop && mRemoveEnabled) {
                     mIsRemoving = true;
                     startDrag(mFlingHitPos, deltaX, deltaY);
                 }


### PR DESCRIPTION
Reduce the chance of unintentionally deleting waypoints while scrolling + scrolling no longer interrupted once in motion.

Possible fix for https://github.com/bauerca/drag-sort-listview/issues/112

Result is more natural / robust scrolling.
