### PR TITLE
MAVLink: added RAW_SENSORS and RC_CHANNELS to preferences

### DIFF
--- a/DroidPlanner/res/xml/preferences.xml
+++ b/DroidPlanner/res/xml/preferences.xml
@@ -52,6 +52,16 @@
                 android:inputType="number"
                 android:key="pref_mavlink_stream_rate_RC_override"
                 android:title="RC override" />
+	        <EditTextPreference
+			        android:defaultValue="5"
+			        android:inputType="number"
+			        android:key="pref_mavlink_stream_rate_rc_channels"
+			        android:title="RC channel data" />
+	        <EditTextPreference
+			        android:defaultValue="2"
+			        android:inputType="number"
+			        android:key="pref_mavlink_stream_rate_raw_sensors"
+			        android:title="Raw sensors" />
         </PreferenceScreen>
     </PreferenceCategory>
     <PreferenceCategory

--- a/DroidPlanner/src/com/droidplanner/MAVLink/MavLinkStreamRates.java
+++ b/DroidPlanner/src/com/droidplanner/MAVLink/MavLinkStreamRates.java
@@ -23,8 +23,10 @@ public class MavLinkStreamRates {
 				"pref_mavlink_stream_rate_extra3", "0"));
 		int position = Integer.parseInt(prefs.getString(
 				"pref_mavlink_stream_rate_position", "0"));
-		int rcChannels = 0;
-		int rawSensors = 0;
+		int rcChannels = Integer.parseInt(prefs.getString(
+				"pref_mavlink_stream_rate_rc_channels", "0"));
+		int rawSensors = Integer.parseInt(prefs.getString(
+				"pref_mavlink_stream_rate_raw_sensors", "0"));
 
 		setupStreamRates(droidPlannerApp.drone.MavClient, extendedStatus,
 				extra1, extra2, extra3, position, rcChannels, rawSensors);


### PR DESCRIPTION
Added RAW_SENSORS and RC_CHANNELS to preferences (Settings -> MavLink -> Stream Rates) with default values 2 and 5 respectively.

RAW_SENSORS and RC_CHANNELS MAVLink data stream rates were not exposed in settings UI, code set both to 0.

This caused some MavLink devices requiring these datas-streams to stop working after connecting to the vehicle with DroidPlanner, eg jDrones IO board running MavLink based LED strip controller.

We were able to reproduce this on a multi-rotor camera ship this afternoon - the LED controller would become unresponsive after connecting with DroidPlanner. The LED controller board was relying on the MavLink RC_CHANNELS data-stream to monitor channel inputs - DP was reconfiguring this data stream to baud rate 0 (disabled).

This fix solves this problem (thanks for finding this one Mike W).
