### PR TITLE
Connection: Use MAVLink heartbeat to monitor connection health

### DIFF
--- a/DroidPlanner/src/com/droidplanner/DroidPlannerApp.java
+++ b/DroidPlanner/src/com/droidplanner/DroidPlannerApp.java
@@ -2,6 +2,7 @@ package com.droidplanner;
 
 import android.app.Application;
 
+import android.os.Handler;
 import com.MAVLink.Messages.MAVLinkMessage;
 import com.MAVLink.Messages.ardupilotmega.msg_heartbeat;
 import com.MAVLink.Messages.enums.MAV_MODE_FLAG;
@@ -16,6 +17,10 @@ import com.droidplanner.service.MAVLinkClient.OnMavlinkClientListner;
 
 public class DroidPlannerApp extends Application implements
 		OnMavlinkClientListner {
+
+	private static long HEARTBEAT_NORMAL_TIMEOUT = 5000;
+	private static long HEARTBEAT_LOST_TIMEOUT = 15000;
+
 	public Drone drone;
 	private MavLinkMsgHandler mavLinkMsgHandler;
 	public FollowMe followMe;
@@ -23,6 +28,21 @@ public class DroidPlannerApp extends Application implements
 	public ConnectionStateListner conectionListner;
 	public OnSystemArmListener onSystemArmListener;
 	private TTS tts;
+
+	enum HeartbeatState {
+		FIRST_HEARTBEAT, LOST_HEARTBEAT, NORMAL_HEARTBEAT
+	}
+
+	private HeartbeatState heartbeatState;
+	private Handler watchdog = new Handler();
+	private Runnable watchdogCallback = new Runnable()
+	{
+		@Override
+		public void run()
+		{
+			onHeartbeatTimeout();
+		}
+	};
 
 	public interface OnWaypointUpdateListner {
 		public void onWaypointsUpdate();
@@ -63,6 +83,7 @@ public class DroidPlannerApp extends Application implements
 			else {
 				notifyDisarmed();
 			}
+			onHeartbeat();
 		}
 		mavLinkMsgHandler.receiveData(msg);
 	}
@@ -71,13 +92,20 @@ public class DroidPlannerApp extends Application implements
 	public void notifyDisconnected() {
 		conectionListner.notifyDisconnected();
 		tts.speak("Disconnected");
+
+		// stop watchdog
+		watchdog.removeCallbacks(watchdogCallback);
 	}
 
 	@Override
 	public void notifyConnected() {
 		MavLinkStreamRates.setupStreamRatesFromPref(this);
 		conectionListner.notifyConnected();
-		tts.speak("Connected");
+		// don't announce 'connected' until first heartbeat received
+
+		// start watchdog
+		heartbeatState = HeartbeatState.FIRST_HEARTBEAT;
+		restartWatchdog(HEARTBEAT_NORMAL_TIMEOUT);
 	}
 
 	@Override
@@ -88,5 +116,34 @@ public class DroidPlannerApp extends Application implements
 	@Override
 	public void notifyDisarmed() {
 		onSystemArmListener.notifyDisarmed();
+	}
+
+	private void onHeartbeat() {
+
+		switch(heartbeatState) {
+			case FIRST_HEARTBEAT:
+				tts.speak("Connected");
+				break;
+
+			case LOST_HEARTBEAT:
+				tts.speak("Data link restored");
+				break;
+		}
+
+		heartbeatState = HeartbeatState.NORMAL_HEARTBEAT;
+		restartWatchdog(HEARTBEAT_NORMAL_TIMEOUT);
+	}
+
+	private void onHeartbeatTimeout() {
+		tts.speak("Data link lost, check connection.");
+		heartbeatState = HeartbeatState.LOST_HEARTBEAT;
+		restartWatchdog(HEARTBEAT_LOST_TIMEOUT);
+	}
+
+	private void restartWatchdog(long timeout)
+	{
+		// re-start watchdog
+		watchdog.removeCallbacks(watchdogCallback);
+		watchdog.postDelayed(watchdogCallback, timeout);
 	}
 }


### PR DESCRIPTION
Goal: to provide greater feedback about data-link status, especially when using bridged connections. 
e.g. [DroidPlaner] -> [BlueTooth] -> [3DR Tx/Rx] -> [APM]

Connection:
- 'Connection' announced only after first MAVLink heartbeat seen (MAVLink session established vs physical connection)

MAVLink heartbeat monitor:
- announce (TTS: "Data link lost, check connection.") if no heartbeat messages received for 5 seconds or more, AND every 15 seconds after until heartbeat messages resume.
- announce (TTS: "Data link restored") on resumption of heartbeats

*\* There is no auto-reconnect etc, it is left to the operator to decide what to do.
