### PR TITLE
Planning: minor - renamed column header [ ^ Home ] -> [ ^ WP ] 

### DIFF
--- a/DroidPlanner/res/layout/activity_planning.xml
+++ b/DroidPlanner/res/layout/activity_planning.xml
@@ -88,7 +88,7 @@
 
                 <TextView
                     android:id="@+id/rowDistanceHeader"
-                    android:layout_width="90dp"
+                    android:layout_width="70dp"
                     android:layout_height="wrap_content"
                     android:text="∆ WP"
                     android:textAppearance="?android:attr/textAppearanceMedium" />

--- a/DroidPlanner/res/layout/row_mission_list.xml
+++ b/DroidPlanner/res/layout/row_mission_list.xml
@@ -20,7 +20,8 @@
         android:id="@+id/rowAltitudeView"
         android:layout_width="70dp"
         android:layout_height="wrap_content"
-        android:gravity="center_horizontal"
+        android:gravity="right"
+        android:paddingRight="8dp"
         android:text="1000m"
         android:textAppearance="?android:attr/textAppearanceMedium" />
 
@@ -35,6 +36,8 @@
         android:id="@+id/rowDistanceView"
         android:layout_width="70dp"
         android:layout_height="wrap_content"
+        android:gravity="right"
+        android:paddingRight="8dp"
         android:text="1000m"
         android:textAppearance="?android:attr/textAppearanceMedium" />
 


### PR DESCRIPTION
Planning:
- distance is inter-waypoint distance, not distance to home
- shrunk column width from 90 to 70 - matches Altitude column and fits revised column header texttext
  ![screenshot_2013-10-14-15-10-31](https://f.cloud.github.com/assets/4014433/1328582/b4bc2078-3504-11e3-86af-71313ac157ba.png)
