### PR TITLE
Fix bug that occurred when trying to update the info panel.

### DIFF
--- a/DroidPlanner/src/com/droidplanner/activitys/FlightActivity.java
+++ b/DroidPlanner/src/com/droidplanner/activitys/FlightActivity.java
@@ -32,7 +32,7 @@ import com.google.android.gms.maps.model.LatLng;
 
 public class FlightActivity extends SuperUI implements
 		OnMapInteractionListener, OnMissionControlInteraction, OnStateListner, ModeChangedListener {
-	private FragmentManager fragmentManager;
+	private static FragmentManager fragmentManager;
 	private RCFragment rcFragment;
 	private View failsafeTextView;
 	private Fragment modeInfoPanel;
@@ -45,21 +45,22 @@ public class FlightActivity extends SuperUI implements
 		modeInfoPanel = fragmentManager.findFragmentById(R.id.modeInfoPanel);
 
 		failsafeTextView = findViewById(R.id.failsafeTextView);
-		drone.state.addFlightStateListner(this);
-		drone.state.addModeChangedListener(this);
-	}
-
-	@Override
-	protected void onDestroy() {
-		super.onDestroy();
-		drone.state.removeFlightStateListner(this);
-		drone.state.removeModeListner(this);
 	}
 
 	@Override
 	protected void onResume() {
 		super.onResume();
+		drone.state.addFlightStateListner(this);
+		drone.state.addModeChangedListener(this);
 		onModeChanged();	// Update the mode detail panel;
+	}
+
+	@Override
+	protected void onStop() {
+		// TODO Auto-generated method stub
+		super.onStop();
+		drone.state.removeModeListner(this);
+		drone.state.removeFlightStateListner(this);
 	}
 
 	@Override


### PR DESCRIPTION
When the mode changed, and the user wasn't on the main screen the app crashed. Because it tried to replace the info panel, which caused an exception.

Fixed by correctly adding mode changes callbacks on the activity lifecycle.
