### PR TITLE
Telemetry Texts Alignment

### DIFF
--- a/DroidPlanner/res/layout/fragment_telemetry.xml
+++ b/DroidPlanner/res/layout/fragment_telemetry.xml
@@ -32,7 +32,7 @@
         android:layout_marginLeft="28dp"
         android:layout_alignTop="@+id/icon_rpy"
         android:layout_marginTop="2dp"
-        android:text="55°"
+        android:text="--°"
         android:textSize="16sp" />
 
     <TextView
@@ -40,10 +40,10 @@
         style="@style/RPYtextLabels"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignLeft="@+id/rollValueText"        
         android:layout_alignBottom="@+id/icon_rpy"
-        android:layout_marginBottom="33dp"
-        android:text="22°"
+        android:layout_alignLeft="@+id/rollValueText"
+        android:layout_marginBottom="34dp"
+        android:text="--°"
         android:textSize="16sp" />
     
     <TextView
@@ -51,14 +51,11 @@
         style="@style/RPYtextLabels"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignLeft="@+id/rollValueText"
         android:layout_alignBottom="@+id/icon_rpy"
-        android:layout_marginBottom="3dp"        
-        android:text="328°"
+        android:layout_alignLeft="@+id/rollValueText"
+        android:layout_marginBottom="2dp"
+        android:text="--°"
         android:textSize="16sp" />
-
-
-    
 
     <com.droidplanner.widgets.newHUD.newHUD
         android:id="@+id/hudView"


### PR DESCRIPTION
Little modification to the Telemetry Data Text field to be better aligned. It's not perfect but hope will not get out of icon fields. Default field values changed to be more "no data" compatible.

![clipboard01](https://f.cloud.github.com/assets/4722993/1796542/e35a1ac0-6a74-11e3-9973-029e85e83465.jpg)
