### PR TITLE
Editor: Adding a menu to revert the mission order

### DIFF
--- a/DroidPlanner/src/com/droidplanner/activitys/EditorActivity.java
+++ b/DroidPlanner/src/com/droidplanner/activitys/EditorActivity.java
@@ -233,20 +233,29 @@ public class EditorActivity extends SuperUI implements OnPathFinishedListner,
 	}
 
 	private static final int MENU_DELETE = 1;
+	private static final int MENU_REVERSE = 2;
 
 	@Override
 	public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
-		if (item.getItemId() == MENU_DELETE) {
+		switch(item.getItemId()){
+		case MENU_DELETE:
 			mission.removeWaypoints(mission.getSelected());
 			notifySelectionChanged();
+			mode.finish();
+			return true;
+		case MENU_REVERSE:
+			mission.reverse();
+			notifySelectionChanged();
+			return true;
+		default:
+			return false;
 		}
-		mode.finish();
-		return false;
 	}
 
 	@Override
 	public boolean onCreateActionMode(ActionMode arg0, Menu menu) {
 		menu.add(0, MENU_DELETE, 0, "Delete");
+		menu.add(0, MENU_REVERSE, 0, "Reverse");
 		editorToolsFragment.getView().setVisibility(View.INVISIBLE);
 		return true;
 	}

--- a/DroidPlanner/src/com/droidplanner/drone/variables/mission/Mission.java
+++ b/DroidPlanner/src/com/droidplanner/drone/variables/mission/Mission.java
@@ -87,6 +87,11 @@ public class Mission extends DroneVariable implements PathSource{
 		myDrone.events.notifyDroneEvent(DroneEventsType.MISSION);		
 	}
 
+	public void reverse() {
+		Collections.reverse(itens);
+		myDrone.events.notifyDroneEvent(DroneEventsType.MISSION);	
+	}
+
 	/**
 	 * Moves the selected objects up or down into the mission listing
 	 * 


### PR DESCRIPTION
While in multi-select mode at the editor screen there is a option to reverse the order of the mission.

I put it there because it's a less used (more advanced) feature.
