### PR TITLE
Updating submodules to DroidPlanner repos

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "usb-serial-for-android"]
 	path = usb-serial-for-android
-	url = https://github.com/arthurbenemann/usb-serial-for-android.git
+	url = https://github.com/DroidPlanner/usb-serial-for-android.git
 [submodule "HorizontalVariableListView"]
 	path = HorizontalVariableListView
-	url = https://github.com/arthurbenemann/HorizontalVariableListView.git
+	url = https://github.com/DroidPlanner/HorizontalListview.git


### PR DESCRIPTION
Updating submodules to DroidPlanner repos.

Also since the forked project of HorizontalVariableListView has gone offline for some reason, I pushed that repo to a new github (as a new project, since the original repo is gone). This points to the updated repository

Thanks Azrin for pointing that to me.
