### PR TITLE
Submodules: Reverting submodule back to our fork of the HorizontalListView

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/DroidPlanner/usb-serial-for-android.git
 [submodule "HorizontalVariableListView"]
 	path = HorizontalVariableListView
-	url = https://github.com/DroidPlanner/HorizontalListview.git
+	url = https://github.com/DroidPlanner/HorizontalVariableListView.git


### PR DESCRIPTION
It was a GitHub problem which is now fixed. So there is no need for our orphan repo for that project.

It's linked to #562.
