### PR TITLE
Small but very useful mavlink lib update.

### DIFF
--- a/Mavlink/src/com/MAVLink/Messages/MAVLinkMessage.java
+++ b/Mavlink/src/com/MAVLink/Messages/MAVLinkMessage.java
@@ -3,7 +3,7 @@ package com.MAVLink.Messages;
 
 import java.io.Serializable;
 
-public class MAVLinkMessage implements Serializable {
+public abstract class MAVLinkMessage implements Serializable {
 	private static final long serialVersionUID = -7754622750478538539L;
 	// The MAVLink message classes have been changed to implement Serializable, 
 	// this way is possible to pass a mavlink message trought the Service-Acctivity interface
@@ -15,6 +15,7 @@ public class MAVLinkMessage implements Serializable {
 	public  int sysid;
 	public int compid;
 	public int msgid;
-	
+	public abstract MAVLinkPacket pack();
+	public abstract void unpack(MAVLinkPayload payload);
 }
 	


### PR DESCRIPTION
MavlinkMessage is an abstract class, in fact. So let's name it as it.

Enables nice calls like msg.pack() on any message. What's more, now it's possible to decode msgs back (msg>packet>msg) even on unknown msg types (ids).
