### PR TITLE
Menus: Fix #589, Renaming to menu to Drone-Setup

### DIFF
--- a/DroidPlanner/AndroidManifest.xml
+++ b/DroidPlanner/AndroidManifest.xml
@@ -113,7 +113,7 @@
             android:name=".activitys.ConfigurationActivity"
             android:windowSoftInputMode="adjustPan"
             android:theme="@style/Theme.PageIndicatorDefaults"
-            android:label="@string/configuration"
+            android:label="@string/menu_drone_setup"
             android:parentActivityName=".activitys.FlightActivity" >
 
             <!-- Parent activity meta-data to support API level 7+ -->

--- a/DroidPlanner/res/menu/menu_super_activiy.xml
+++ b/DroidPlanner/res/menu/menu_super_activiy.xml
@@ -3,9 +3,9 @@
     xmlns:tools="http://schemas.android.com/tools" >
     
     <item
-        android:id="@+id/menu_configuration"
+        android:id="@+id/menu_drone_setup"
         android:showAsAction="never"
-        android:title="@string/configuration"/>
+        android:title="@string/menu_drone_setup"/>
     <item
         android:id="@+id/menu_settings"
         android:showAsAction="never"

--- a/DroidPlanner/res/values/strings.xml
+++ b/DroidPlanner/res/values/strings.xml
@@ -7,7 +7,7 @@
     <string name="storage_folder">Storage Folder</string>
     <string name="settings">Settings</string>
     <string name="help">Help</string>
-    <string name="configuration">Configuration</string>
+    <string name="menu_drone_setup">Drone Setup</string>
     <string name="editor">Editor</string>
     <string name="menu_connect">Connect</string>
     <string name="menu_disconnect">Disconnect</string>

--- a/DroidPlanner/src/org/droidplanner/activitys/helpers/SuperActivity.java
+++ b/DroidPlanner/src/org/droidplanner/activitys/helpers/SuperActivity.java
@@ -41,7 +41,7 @@ public abstract class SuperActivity extends HelpActivity implements
 	@Override
 	public boolean onMenuItemSelected(int featureId, MenuItem item) {
 		switch (item.getItemId()) {
-		case R.id.menu_configuration:
+		case R.id.menu_drone_setup:
 			startActivity(new Intent(this, ConfigurationActivity.class));
 			return true;
 		case R.id.menu_settings:


### PR DESCRIPTION
Fix #589 by changing the menu to the "Drone Setup/Settings".
