### PR TITLE
Parameters: fix for #559, crash when focus lost w/ unparsable value

### DIFF
--- a/DroidPlanner/src/org/droidplanner/adapters/ParamsAdapter.java
+++ b/DroidPlanner/src/org/droidplanner/adapters/ParamsAdapter.java
@@ -242,7 +242,8 @@ public class ParamsAdapter extends ArrayAdapter<ParamsAdapterItem> {
             try {
                 return formatter.parse(valueView.getText().toString()).doubleValue();
             } catch (ParseException ex) {
-                throw new NumberFormatException(ex.getMessage());
+                // invalid number, return 0
+                return 0;
             }
         }
 


### PR DESCRIPTION
(e.g. blank) numeric value in edit box - return 0
