### PR TITLE
Update Canon SX260 SX280 HS.xml

### DIFF
--- a/DroidPlanner/assets/CameraInfo/Canon SX260 SX280 HS.xml
+++ b/DroidPlanner/assets/CameraInfo/Canon SX260 SX280 HS.xml
@@ -4,6 +4,6 @@
     <SensorWidth>6.17</SensorWidth>
     <SensorHeight>4.55</SensorHeight>
     <SensorResolution>12.1</SensorResolution>
-    <FocalLength>4.5</FocalLength>
-    <Orientation>Portrait</Orientation> 
+    <FocalLength>5</FocalLength>
+    <Orientation>Landscape</Orientation> 
 </cameraInfo>


### PR DESCRIPTION
Corrected focal length ( from 4.5 to 5 0 ) and orientation ( to landscape, most appropriate for mapping applications )
