### PR TITLE
HeartBeat: Fixed problem with the Drone HeartBeat detector.

### DIFF
--- a/DroidPlanner/src/org/droidplanner/drone/variables/HeartBeat.java
+++ b/DroidPlanner/src/org/droidplanner/drone/variables/HeartBeat.java
@@ -14,7 +14,7 @@ public class HeartBeat extends DroneVariable implements OnDroneListener {
 	private static long HEARTBEAT_NORMAL_TIMEOUT = 5000;
 	private static long HEARTBEAT_LOST_TIMEOUT = 15000;
 
-	public HeartbeatState heartbeatState;
+	public HeartbeatState heartbeatState = HeartbeatState.FIRST_HEARTBEAT;;
 	public int droneID = 1;
 
 	enum HeartbeatState {
@@ -67,12 +67,12 @@ public class HeartBeat extends DroneVariable implements OnDroneListener {
 	}
 
 	private void notifyConnected() {
-		heartbeatState = HeartbeatState.FIRST_HEARTBEAT;
 		restartWatchdog(HEARTBEAT_NORMAL_TIMEOUT);
 	}
 
 	private void notifiyDisconnected() {
 		watchdog.removeCallbacks(watchdogCallback);
+		heartbeatState = HeartbeatState.FIRST_HEARTBEAT;
 	}
 
 	private void onHeartbeatTimeout() {


### PR DESCRIPTION
It was re-staring the heartbeat counter every time there was a disconnect, which in turn caused a new FIRST_HEARTBEAT event every-time a new screen was open.

This fix the issue of having the app saying "connected" every time a new screen was opened. #660
