### PR TITLE
Parameter retrieval update

### DIFF
--- a/DroidPlanner/src/org/droidplanner/MAVLink/MavLinkMsgHandler.java
+++ b/DroidPlanner/src/org/droidplanner/MAVLink/MavLinkMsgHandler.java
@@ -28,8 +28,11 @@ public class MavLinkMsgHandler {
 	}
 
 	public void receiveData(MAVLinkMessage msg) {
+		if(drone.parameters.processMessage(msg)) {
+		    return;
+		}
+
 		drone.waypointMananger.processMessage(msg);
-		drone.parameters.processMessage(msg);
 		drone.calibrationSetup.processMessage(msg);
 
 		switch (msg.msgid) {

--- a/DroidPlanner/src/org/droidplanner/connection/MAVLinkConnection.java
+++ b/DroidPlanner/src/org/droidplanner/connection/MAVLinkConnection.java
@@ -103,7 +103,6 @@ public abstract class MAVLinkConnection extends Thread {
 				listener.onReceiveMessage(msg);
 			}
 		}
-
 	}
 
 	private void saveToLog(MAVLinkPacket receivedPacket) throws IOException {

--- a/DroidPlanner/src/org/droidplanner/drone/variables/Parameters.java
+++ b/DroidPlanner/src/org/droidplanner/drone/variables/Parameters.java
@@ -10,6 +10,8 @@ import org.droidplanner.drone.DroneInterfaces.DroneEventsType;
 import org.droidplanner.drone.DroneVariable;
 import org.droidplanner.parameters.Parameter;
 
+import android.util.Log;
+
 import com.MAVLink.Messages.MAVLinkMessage;
 import com.MAVLink.Messages.ardupilotmega.msg_param_value;
 
@@ -22,9 +24,12 @@ import com.MAVLink.Messages.ardupilotmega.msg_param_value;
  *
  */
 public class Parameters extends DroneVariable {
-    private List<Parameter> parameters = new ArrayList<Parameter>();
+	private static final String TAG = Parameters.class.getSimpleName();
+
+	private List<Parameter> parameters = new ArrayList<Parameter>();
 
 	public DroneInterfaces.OnParameterManagerListener parameterListener;
+	private int paramsReceived = 0;
 
 	public Parameters(Drone myDrone) {
 		super(myDrone);
@@ -32,6 +37,7 @@ public class Parameters extends DroneVariable {
 
 	public void getAllParameters() {
 		parameters.clear();
+		paramsReceived = 0;
 		if(parameterListener!=null)
 			parameterListener.onBeginReceivingParameters();
 		MavLinkParameters.requestParametersList(myDrone);
@@ -46,7 +52,7 @@ public class Parameters extends DroneVariable {
 	 */
 	public boolean processMessage(MAVLinkMessage msg) {
 		if (msg.msgid == msg_param_value.MAVLINK_MSG_ID_PARAM_VALUE) {
-				processReceivedParam((msg_param_value) msg);
+			processReceivedParam((msg_param_value) msg);
 			return true;
 		}
 		return false;
@@ -61,11 +67,17 @@ public class Parameters extends DroneVariable {
 		if(parameterListener!=null)
 			parameterListener.onParameterReceived(param, m_value.param_index, m_value.param_count);
 
-		// last param? notify listener w/ params
-		if (m_value.param_index == m_value.param_count - 1) {
-			if(parameterListener!=null)
-				parameterListener.onEndReceivingParameters(parameters);
+		if(m_value.param_index > paramsReceived) {
+			Log.w(TAG, "Skipped index: Index is " + m_value.param_index + " received=" + paramsReceived);
 		}
+
+		// last param? Notify the listener with the parameters
+		if(++paramsReceived >= m_value.param_count - 1) {
+		    if(parameterListener != null) {
+		        parameterListener.onEndReceivingParameters(parameters);
+		    }
+		}
+
 		myDrone.events.notifyDroneEvent(DroneEventsType.PARAMETER);
 	}
 

--- a/DroidPlanner/src/org/droidplanner/fragments/ParamsFragment.java
+++ b/DroidPlanner/src/org/droidplanner/fragments/ParamsFragment.java
@@ -23,6 +23,7 @@ import org.droidplanner.parameters.ParameterMetadata;
 import android.app.ProgressDialog;
 import android.os.Bundle;
 import android.support.v4.app.ListFragment;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -34,6 +35,7 @@ import android.widget.Toast;
 
 public class ParamsFragment extends ListFragment implements DroneInterfaces
         .OnParameterManagerListener, OnDroneListener{
+    static final String TAG = ParamsFragment.class.getSimpleName();
 
     public static final String ADAPTER_ITEMS = ParamsFragment.class.getName() + ".adapter.items";
 
@@ -228,21 +230,33 @@ public class ParamsFragment extends ListFragment implements DroneInterfaces
         progressDialog.setCanceledOnTouchOutside(true);
 
         progressDialog.show();
+
+        mReceived = 0;
+        mTotal = 0;
     }
+
+    private int mReceived = 0, mTotal = 0;
 
     @Override
     public void onParameterReceived(Parameter parameter, int index, int count) {
+        ++mReceived;
+
         if (progressDialog != null) {
             if (progressDialog.isIndeterminate()) {
                 progressDialog.setIndeterminate(false);
+                mTotal = count;
                 progressDialog.setMax(count);
             }
-            progressDialog.setProgress(index);
+            progressDialog.setProgress(mReceived);
         }
     }
 
     @Override
     public void onEndReceivingParameters(List<Parameter> parameters) {
+        if(mReceived < mTotal) {
+            Log.w(TAG, "Total of " + mTotal + " params, but only got " + mReceived);
+        }
+
         Collections.sort(parameters, new Comparator<Parameter>() {
             @Override
             public int compare(Parameter p1, Parameter p2) {


### PR DESCRIPTION
This update changes the way the app determines when it is finished loading parameters from the MAV. It maintains a count of the total number of parameters received vs. the total number of available parameters. The other method uses the index of a given parameter vs. the total parameter count. The issue is that on a USB->wireless Mavlink connection, buffer overflows occur, causing parameters to be missed. The app receives the last parameter (by index) and assumes it's complete, but returns an incomplete parameter list. 
fix #710
