### PR TITLE
Issue #719 Fix Mode Change for copter other than Quad

### DIFF
--- a/Mavlink/src/com/MAVLink/Messages/ApmModes.java
+++ b/Mavlink/src/com/MAVLink/Messages/ApmModes.java
@@ -64,6 +64,10 @@ public enum ApmModes {
 	}
 
 	public static ApmModes getMode(int i, int type) {
+        if (isCopter(type)) {
+            type = MAV_TYPE.MAV_TYPE_QUADROTOR;
+        }
+
 		for (ApmModes mode : ApmModes.values()) {
 			if (i == mode.getNumber() & type == mode.getType()) {
 				return mode;


### PR DESCRIPTION
Issue #719 When changing a mode either using the remote or the tablet,
Droidplanner did not correctly show the current set mode for copter
types other than MAV_TYPE_QUADROTOR.
This was due to the enumeration of the modes only having modes for
QUADROTOR.
