### PR TITLE
CORE: Changing Coord2D structure to be equal to the MAVLink standard.

### DIFF
--- a/Android/src/org/droidplanner/android/graphic/DroneHelper.java
+++ b/Android/src/org/droidplanner/android/graphic/DroneHelper.java
@@ -13,7 +13,7 @@ public class DroneHelper {
 	}
 
 	public static Coord2D LatLngToCoord(LatLng point) {
-		return new Coord2D(point.longitude, point.latitude);
+		return new Coord2D(point.latitude, point.longitude);
 	}
 
 	public static List<LatLng> CoordToLatLang(

--- a/Core/src/org/droidplanner/core/MAVLink/MavLinkMsgHandler.java
+++ b/Core/src/org/droidplanner/core/MAVLink/MavLinkMsgHandler.java
@@ -68,8 +68,8 @@ public class MavLinkMsgHandler {
 			break;
 		case msg_global_position_int.MAVLINK_MSG_ID_GLOBAL_POSITION_INT:
 			drone.GPS.setPosition(new Coord2D(
-					((msg_global_position_int) msg).lon / 1E7,
-					((msg_global_position_int) msg).lat / 1E7));
+					((msg_global_position_int) msg).lat / 1E7,
+					((msg_global_position_int) msg).lon / 1E7));
 			break;
 		case msg_sys_status.MAVLINK_MSG_ID_SYS_STATUS:
 			msg_sys_status m_sys = (msg_sys_status) msg;

--- a/Core/src/org/droidplanner/core/drone/variables/Home.java
+++ b/Core/src/org/droidplanner/core/drone/variables/Home.java
@@ -44,7 +44,7 @@ public class Home extends DroneVariable {
 	}
 
 	public void setHome(msg_mission_item msg) {
-		this.coordinate = new Coord2D(msg.y, msg.x); // MAVlink has y as longitude.
+		this.coordinate = new Coord2D(msg.x, msg.y);
 		this.altitude = new Altitude(msg.z);
 		myDrone.events.notifyDroneEvent(DroneEventsType.HOME);
 	}
@@ -57,8 +57,8 @@ public class Home extends DroneVariable {
 		mavMsg.target_component = 1;
 		mavMsg.target_system = 1;
 		if (isValid()) {
-			mavMsg.x = (float) getCoord().getX();
-			mavMsg.y = (float) getCoord().getY();
+			mavMsg.x = (float) getCoord().getLat();
+			mavMsg.y = (float) getCoord().getLng();
 			mavMsg.z = (float) getAltitude().valueInMeters();
 		}
 		return mavMsg;

--- a/Core/src/org/droidplanner/core/helpers/coordinates/Coord2D.java
+++ b/Core/src/org/droidplanner/core/helpers/coordinates/Coord2D.java
@@ -1,45 +1,45 @@
 package org.droidplanner.core.helpers.coordinates;
 
 public class Coord2D {
-	private double x; // aka Longitude
-	private double y; // aka Latitude
+	private double latitude;  // aka x
+	private double longitude; // aka y
 
-	public Coord2D(double x, double y) {
-		set(x, y);
+	public Coord2D(double lat, double lon) {
+		set(lat, lon);
 	}
 
 	public Coord2D(Coord2D point) {
 		set(point);
 	}
 
-	public void set(double x, double y) {
-		this.x = x;
-		this.y = y;
+	public void set(double lat, double lon) {
+		this.latitude = lat;
+		this.longitude = lon;
 	}
 
 	public void set(Coord2D coord) {
-		set(coord.x, coord.y);
+		set(coord.latitude, coord.longitude);
 	}
 
 	public double getX() {
-		return x;
+		return latitude;
 	}
 
 	public double getY() {
-		return y;
+		return longitude;
 	}
 
 	public double getLng() {
-		return x;
+		return longitude;
 	}
 
 	public double getLat() {
-		return y;
+		return latitude;
 	}
 
 	@Override
 	public String toString() {
-		return "X/Y: " + getX() + "/" + getY();
+		return "lat/lon: " + getLat() + "/" + getLng();
 	}
 
 }

--- a/Core/src/org/droidplanner/core/helpers/coordinates/Coord3D.java
+++ b/Core/src/org/droidplanner/core/helpers/coordinates/Coord3D.java
@@ -5,21 +5,21 @@ import org.droidplanner.core.helpers.units.Altitude;
 public class Coord3D extends Coord2D {
 	private Altitude alt;
 
-	public Coord3D(double x, double y, Altitude alt) {
-		super(x, y);
+	public Coord3D(double lat, double lon, Altitude alt) {
+		super(lat, lon);
 		this.alt = alt;
 	}
 
 	public Coord3D(Coord2D point, Altitude alt) {
-		this(point.getX(), point.getY(), alt);
+		this(point.getLat(), point.getLng(), alt);
 	}
 
-	public Coord3D(int x, int y, int alt) {
-		this(x, y, new Altitude(alt));
+	public Coord3D(int lat, int lon, int alt) {
+		this(lat, lon, new Altitude(alt));
 	}
 
-	public void set(double x, double y, Altitude alt) {
-		super.set(x, y);
+	public void set(double lat, double lon, Altitude alt) {
+		super.set(lat, lon);
 		this.alt = alt;
 	}
 

--- a/Core/src/org/droidplanner/core/mission/waypoints/SpatialCoordItem.java
+++ b/Core/src/org/droidplanner/core/mission/waypoints/SpatialCoordItem.java
@@ -49,11 +49,11 @@ public abstract class SpatialCoordItem extends MissionItem {
 	@Override
 	public void unpackMAVMessage(msg_mission_item mavMsg) {
 		Altitude alt = new Altitude(mavMsg.z);
-		setCoordinate(new Coord3D(mavMsg.y, mavMsg.x, alt)); // For MAVLink x is Latitude, and y is Longitude, that`s why this is reversed.
+		setCoordinate(new Coord3D(mavMsg.x, mavMsg.y, alt));
 	}
 
 	public void setAltitude(Altitude altitude) {
-		coordinate.set(coordinate.getX(), coordinate.getY(), altitude);
+		coordinate.set(coordinate.getLat(), coordinate.getLng(), altitude);
 	}
 
 	public void setPosition(Coord2D position) {

--- a/Core/test/org/droidplanner/core/mission/waypoints/SpatialCoordItemTest.java
+++ b/Core/test/org/droidplanner/core/mission/waypoints/SpatialCoordItemTest.java
@@ -22,8 +22,8 @@ public class SpatialCoordItemTest extends TestCase {
 		assertEquals(1, mavMsg.target_component);
 		assertEquals(1, mavMsg.target_system);
 		assertEquals(MAV_FRAME.MAV_FRAME_GLOBAL_RELATIVE_ALT, mavMsg.frame);
-		assertEquals(1f, mavMsg.x);
-		assertEquals(0.1f, mavMsg.y);
+		assertEquals(0.1f, mavMsg.x);
+		assertEquals(1f, mavMsg.y);
 		assertEquals(2f, mavMsg.z);
 	}
 


### PR DESCRIPTION
This is a follow-up on #735.

I made Coord2D equal to the mavlink standard. Meaning:
X - Latitude (North)
Y - Longitude (East)
