### PR TITLE
Android-studio versionName update

### DIFF
--- a/Android/build.gradle
+++ b/Android/build.gradle
@@ -14,6 +14,11 @@ dependencies {
 android {
     compileSdkVersion 19
     buildToolsVersion '19.0.1'
+
+    defaultConfig {
+        versionName getGitVersion()
+    }
+
     sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'
@@ -38,4 +43,10 @@ android {
         release.setRoot('build-types/release')
     }
 
+}
+
+def getGitVersion(){
+    def cmd = "git describe --tag --dirty"
+    def proc = cmd.execute()
+    return proc.text.trim()
 }


### PR DESCRIPTION
Updated Android project gradle build file to update the version name with the git tag info.
This replicates 'version.sh' functionality for android-studio.
