### PR TITLE
Layout: adding support for Galaxy Note 3

### DIFF
--- a/Android/AndroidManifest.xml
+++ b/Android/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="org.droidplanner"
-          android:versionCode="73"
+          android:versionCode="75"
           android:versionName="please run version.sh to get the version name">
 
     <uses-sdk

--- a/Android/res/layout/fragment_telemetry.xml
+++ b/Android/res/layout/fragment_telemetry.xml
@@ -11,87 +11,72 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
-        android:paddingLeft="5dp"
-        android:paddingRight="5dp"
-        android:paddingBottom="5dp"
-        android:paddingTop="5dp">
-
-        <TextView
-            android:id="@+id/rollValueText"
-            style="@style/RPYtextLabels"
-            android:layout_width="70dp"
-            android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:layout_marginBottom="3dp"
-            android:drawableLeft="@drawable/roll_icon"
-            android:background="@drawable/round_rect_bg"
-            android:paddingTop="1dp"
-            android:paddingBottom="1dp"
-            android:paddingRight="10dp"
-            android:paddingEnd="10dp"
-            android:paddingLeft="1dp"
-            android:paddingStart="1dp"
-            android:text="@string/default_angle_value"
-            android:drawablePadding="2dp"
-            android:textSize="16sp"/>
-
-        <TextView
-            android:id="@+id/pitchValueText"
-            style="@style/RPYtextLabels"
-            android:layout_width="70dp"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="3dp"
-            android:layout_alignLeft="@+id/rollValueText"
-            android:layout_alignStart="@+id/rollValueText"
-            android:layout_below="@+id/rollValueText"
-            android:drawableLeft="@drawable/pitch_icon"
-            android:background="@drawable/round_rect_bg"
-            android:paddingTop="1dp"
-            android:paddingBottom="1dp"
-            android:paddingRight="10dp"
-            android:paddingEnd="10dp"
-            android:paddingLeft="1dp"
-            android:paddingStart="1dp"
-            android:drawablePadding="2dp"
-            android:text="@string/default_angle_value"
-            android:textSize="16sp"/>
+        android:paddingLeft="1dp"
+        android:paddingRight="1dp"
+        android:paddingBottom="1dp"
+        android:paddingTop="2dp">
 
         <TextView
             android:id="@+id/yawValueText"
             style="@style/RPYtextLabels"
-            android:layout_width="70dp"
+            android:layout_width="55dp"
             android:layout_height="wrap_content"
+            android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
             android:layout_marginBottom="3dp"
-            android:layout_alignLeft="@+id/rollValueText"
-            android:layout_alignStart="@+id/rollValueText"
-            android:layout_below="@+id/pitchValueText"
-            android:drawableLeft="@drawable/yaw_icon"
             android:background="@drawable/round_rect_bg"
-            android:paddingTop="1dp"
-            android:paddingBottom="1dp"
-            android:paddingRight="10dp"
-            android:paddingEnd="10dp"
-            android:paddingLeft="1dp"
-            android:paddingStart="1dp"
+            android:drawableLeft="@drawable/yaw_icon"
+            android:focusable="true"
+            android:gravity="left|center_vertical"
+            android:text="359"
+            android:textSize="16sp" />
+
+        <TextView
+            android:id="@+id/pitchValueText"
+            style="@style/RPYtextLabels"
+            android:layout_width="55dp"
+            android:layout_height="wrap_content"
+            android:layout_alignLeft="@+id/yawValueText"
+            android:layout_alignStart="@+id/yawValueText"
+            android:layout_below="@+id/yawValueText"
+            android:layout_marginBottom="3dp"
+            android:background="@drawable/round_rect_bg"
+            android:drawableLeft="@drawable/pitch_icon"
             android:drawablePadding="2dp"
+            android:gravity="left|center_vertical"
             android:text="@string/default_angle_value"
-            android:textSize="16sp"/>
+            android:textSize="16sp" />
+
+        <TextView
+            android:id="@+id/rollValueText"
+            style="@style/RPYtextLabels"
+            android:layout_width="55dp"
+            android:layout_height="wrap_content"
+            android:layout_alignLeft="@+id/pitchValueText"
+            android:layout_alignStart="@+id/pitchValueText"
+            android:layout_below="@+id/pitchValueText"
+            android:layout_marginBottom="3dp"
+            android:background="@drawable/round_rect_bg"
+            android:drawableLeft="@drawable/roll_icon"
+            android:drawablePadding="2dp"
+            android:gravity="left|center_vertical"
+            android:text="@string/default_angle_value"
+            android:textSize="16sp" />
 
         <org.droidplanner.android.widgets.AttitudeIndicator
             android:id="@+id/aiView"
             android:layout_width="80dp"
             android:layout_height="80dp"
-            android:layout_toRightOf="@+id/rollValueText"
-            android:layout_alignTop="@+id/rollValueText"
-            android:layout_alignBottom="@+id/yawValueText"
+            android:layout_toRightOf="@+id/yawValueText"
+            android:layout_alignTop="@+id/yawValueText"
+            android:layout_alignBottom="@+id/rollValueText"
             tools:ignore="ContentDescription"/>
 
         <!-- ************** GROUND SPEED ********************* -->
 
         <RelativeLayout
             android:id="@+id/ground_speed_layout"
-            android:layout_below="@+id/yawValueText"
+            android:layout_below="@+id/rollValueText"
             android:layout_marginBottom="3dp"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/Android/res/values/dimens.xml
+++ b/Android/res/values/dimens.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Dimension for the telemetry ui elements -->
-    <dimen name="largeTelemetryTextSize">30sp</dimen>
+    <dimen name="largeTelemetryTextSize">18sp</dimen>
 
     <!-- Dimension for the flight control buttons -->
     <dimen name="flightControlMargin">0dp</dimen>


### PR DESCRIPTION
DisplayMetrics{density=3.0, width=1080, height=1920, scaledDensity=2.3700001, xdpi=386.366, ydpi=387.047}
This is submited in the main layout folder per Arthur's request. He plans to create the -sw folders
