### PR TITLE
Gradle build files update to support android-studio v0.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.iml
 local.properties
 .gradle
+build/

--- a/Android/build.gradle
+++ b/Android/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 
 android {
     compileSdkVersion 19
-    buildToolsVersion '19.0.1'
+    buildToolsVersion '19.1.0'
 
     defaultConfig {
         versionName getGitVersion()

--- a/Core/build.gradle
+++ b/Core/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 
 android {
     compileSdkVersion 19
-    buildToolsVersion "19.0.1"
+    buildToolsVersion "19.1.0"
 
     sourceSets {
         main {

--- a/HorizontalVariableListView/HorizontalVariableListView/build.gradle
+++ b/HorizontalVariableListView/HorizontalVariableListView/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 
 android {
     compileSdkVersion 19
-    buildToolsVersion "19.0.1"
+    buildToolsVersion "19.1.0"
 
     defaultConfig {
         minSdkVersion 9

--- a/Mavlink/build.gradle
+++ b/Mavlink/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
 android {
     compileSdkVersion 19
-    buildToolsVersion "19.0.1"
+    buildToolsVersion "19.1.0"
 
     sourceSets {
         main {

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,6 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:0.+'
     }
 }

--- a/usb-serial-for-android/UsbSerialLibrary/build.gradle
+++ b/usb-serial-for-android/UsbSerialLibrary/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android-library'
 
 android {
     compileSdkVersion 19
-    buildToolsVersion "19.0.1"
+    buildToolsVersion "19.1.0"
 
     sourceSets {
         main {


### PR DESCRIPTION
The changes include:
- Update of the `.gitignore` file to ignore the `build` directory generated by android-studio during the build and compilation process.
- Update of the project gradle build file to support `0.6.0` and prior versions of android-studio
- Update of the sub-projects gradle build file in order to upgrade the android build tools to version 19.1.0 (a requirement of android-studio v0.6.0).
