### PR TITLE
Fix travis ci failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: android
 android:
   components:
-  - build-tools-19.1.0
+    - build-tools-19.1.0
+  licenses:
+    - 'android-sdk-license-.+'
 
 script:
     - ./gradlew build


### PR DESCRIPTION
During build, the ci vm download the android tools, and accompanying licenses. As noted in the documentation (http://docs.travis-ci.com/user/languages/android/) without any `licenses` configuration for the `android language`, the vm will only accept the `android-sdk-license-bcbbd656` license. 
I added a regular expression for the `license` argument so it's able to handle future variation of the android sdk license.

Note: the license most likely changes because of Google IO, and the release of new android sdk tools. 
