### PR TITLE
Bugfix: Use correct method to check the volume preference

### DIFF
--- a/Android/src/org/droidplanner/android/activities/helpers/SuperUI.java
+++ b/Android/src/org/droidplanner/android/activities/helpers/SuperUI.java
@@ -78,7 +78,7 @@ public abstract class SuperUI extends FragmentActivity implements OnDroneListene
 	}
 
 	private void maxVolumeIfEnabled() {
-		if (mAppPrefs.keepScreenOn()) {
+		if (mAppPrefs.maxVolumeOnStart()) {
 			AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
 			audioManager.setStreamVolume(AudioManager.STREAM_MUSIC,
 			    audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC),


### PR DESCRIPTION
Fixing a dumb change made at #840.
https://github.com/DroidPlanner/droidplanner/pull/840#issuecomment-47614210
