### PR TITLE
GpsInfo: added advanced setting to display HDOP instead of FIX

### DIFF
--- a/Android/res/values/strings.xml
+++ b/Android/res/values/strings.xml
@@ -384,4 +384,7 @@
     <string name="pref_permanent_notification_title">Enable permanent notification</string>
     <string name="pref_permanent_notification_summary">Enable to make status bar notification permanent when connected.</string>
 
+    <string name="pref_ui_gps_hdop_summary">Display HDOP instead of FIX in satellite info bar item</string>
+    <string name="pref_ui_gps_hdop_title">Display Satellite HDOP</string>
+
 </resources>

--- a/Android/res/xml/preferences.xml
+++ b/Android/res/xml/preferences.xml
@@ -110,6 +110,12 @@
                 android:summary="@string/pref_vehicle_type_summary"
                 android:title="@string/pref_vehicle_type" />
 
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="pref_ui_gps_hdop"
+                android:summary="@string/pref_ui_gps_hdop_summary"
+                android:title="@string/pref_ui_gps_hdop_title"/>
+
             <PreferenceScreen
                 android:key="pref_rc"
                 android:title="@string/pref_rc" >

--- a/Android/src/org/droidplanner/android/utils/Constants.java
+++ b/Android/src/org/droidplanner/android/utils/Constants.java
@@ -15,6 +15,8 @@ public class Constants {
      */
     public static final String PREF_BLUETOOTH_DEVICE_ADDRESS = "pref_bluetooth_device_address";
 
+    public static final String PREF_UI_GPS_HDOP = "pref_ui_gps_hdop";
+
     /**
      * Sets whether or not the default language for the ui should be english.
      */

--- a/Android/src/org/droidplanner/android/widgets/actionProviders/InfoBarItem.java
+++ b/Android/src/org/droidplanner/android/widgets/actionProviders/InfoBarItem.java
@@ -1,7 +1,9 @@
 package org.droidplanner.android.widgets.actionProviders;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Handler;
+import android.preference.PreferenceManager;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -13,6 +15,7 @@ import android.widget.TextView;
 import com.MAVLink.Messages.ApmModes;
 
 import org.droidplanner.R;
+import org.droidplanner.android.utils.Constants;
 import org.droidplanner.core.drone.Drone;
 import org.droidplanner.android.widgets.spinners.ModeAdapter;
 import org.droidplanner.android.widgets.spinners.SpinnerSelfSelect;
@@ -129,9 +132,19 @@ public abstract class InfoBarItem {
 		@Override
 		public void updateItemView(final Context context, final Drone drone) {
 			if (mItemView != null) {
-				String update = drone == null ? "--" : String.format(
-						"Satellite\n%d, %s", drone.GPS.getSatCount(),
-						drone.GPS.getFixType());
+                final SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(context);
+                final boolean displayHdop = settings.getBoolean(Constants.PREF_UI_GPS_HDOP, false);
+
+                final String update;
+                if(drone == null) {
+                    update = "--";
+                } else if(displayHdop) {
+                    update = String.format("Satellite\n%d, %.1f", drone.GPS.getSatCount(),
+                            drone.GPS.getGpsEPH());
+                } else {
+                    update = String.format("Satellite\n%d, %s", drone.GPS.getSatCount(),
+                            drone.GPS.getFixType());
+                }
 
 				((TextView) mItemView).setText(update);
 			}


### PR DESCRIPTION
We depend on HDOP as measure of GPS reliability. GPS will report 'GPS 3D Lock' with as few as 4 satellites and an HDOP of 10+. We don't depend on GPS if HDOP values are > 2 where we fly.

Added an advanced option to replace '3D Fix/No Fix' w/ numeric HDOP value in satellite info panel.

![screenshot_2014-07-08-10-21-15](https://cloud.githubusercontent.com/assets/4014433/3511025/400664f8-06ac-11e4-9302-024fd446e8fe.png)
