### PR TITLE
BTConnection: Remember selected BT connection...

### DIFF
--- a/Android/res/values/preferences_keys.xml
+++ b/Android/res/values/preferences_keys.xml
@@ -18,6 +18,7 @@ This file is used to store the preferences keys so that it's accessible and modi
     <string name="pref_server_ip_key">pref_server_ip</string>
     <string name="pref_server_port_key">pref_server_port</string>
     <string name="pref_udp_server_port_key">pref_udp_server_port</string>
+    <string name="pref_bluetooth_device_address_key">pref_bluetooth_device_address</string>
     <string name="pref_vehicle_type_key">pref_vehicle_type</string>
     <string name="pref_rc_quickmode_right_key">pref_rc_quickmode_right</string>
     <string name="pref_rc_quickmode_left_key">pref_rc_quickmode_left</string>

--- a/Android/res/values/strings.xml
+++ b/Android/res/values/strings.xml
@@ -381,7 +381,12 @@
     <string name="usage_statistics">Usage Statistics</string>
     <string name="pref_usage_statistics_title">Send usage statistics</string>
     <string name="pref_usage_statistics_summary">Help improve DroidPlanner by sending usage statistics.</string>
+
     <string name="pref_permanent_notification_title">Enable permanent notification</string>
     <string name="pref_permanent_notification_summary">Enable to make status bar notification permanent when connected.</string>
 
+    <string name="pref_bluetooth">BLUETOOTH CONNECTION</string>
+    <string name="pref_bluetooth_device_address">Bluetooth device</string>
+    <string name="pref_ui_gps_hdop_summary">Display HDOP instead of FIX in satellite info bar item</string>
+    <string name="pref_ui_gps_hdop_title">Display Satellite HDOP</string>
 </resources>

--- a/Android/res/xml/preferences.xml
+++ b/Android/res/xml/preferences.xml
@@ -217,6 +217,15 @@
                         android:key="@string/pref_udp_server_port_key"
                         android:title="@string/pref_udp_server_port" />
                 </PreferenceCategory>
+                <PreferenceCategory
+                    android:key="pref_bluetooth"
+                    android:title="@string/pref_bluetooth">
+                    <EditTextPreference
+                        android:defaultValue=""
+                        android:gravity="center"
+                        android:key="pref_bluetooth_device_address"
+                        android:title="@string/pref_bluetooth_device_address"/>
+                </PreferenceCategory>
             </PreferenceScreen>
             <PreferenceScreen
                 android:key="pref_mavlink_rates"

--- a/Android/src/org/droidplanner/android/activities/helpers/SuperUI.java
+++ b/Android/src/org/droidplanner/android/activities/helpers/SuperUI.java
@@ -4,6 +4,7 @@ import org.droidplanner.R;
 import org.droidplanner.android.DroidPlannerApp;
 import org.droidplanner.android.fragments.helpers.BTDeviceListFragment;
 import org.droidplanner.android.maps.providers.google_map.GoogleMapFragment;
+import org.droidplanner.android.utils.Constants;
 import org.droidplanner.android.utils.prefs.DroidPlannerPrefs;
 import org.droidplanner.android.utils.Utils;
 import org.droidplanner.android.widgets.actionProviders.InfoBarActionProvider;
@@ -15,6 +16,7 @@ import org.droidplanner.core.gcs.GCSHeartbeat;
 import android.app.ActionBar;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.media.AudioManager;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
@@ -228,10 +230,13 @@ public abstract class SuperUI extends FragmentActivity implements OnDroneListene
 
 			if (Utils.ConnectionType.BLUETOOTH.name().equals(connectionType)) {
 				// Launch a bluetooth device selection screen for the user
-				new BTDeviceListFragment().show(getSupportFragmentManager(),
-						"Device selection dialog");
-				return;
-			}
+                final SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(this);
+                final String address = settings.getString(Constants.PREF_BLUETOOTH_DEVICE_ADDRESS, null);
+                if(address == null || address.isEmpty()) {
+                    new BTDeviceListFragment().show(getSupportFragmentManager(), "Device selection dialog");
+                    return;
+                }
+            }
 		}
 		drone.MavClient.toggleConnectionState();
 	}

--- a/Android/src/org/droidplanner/android/communication/connection/BluetoothConnection.java
+++ b/Android/src/org/droidplanner/android/communication/connection/BluetoothConnection.java
@@ -42,16 +42,26 @@ public class BluetoothConnection extends MAVLinkConnection {
 		// Reset the bluetooth connection
 		resetConnection();
 
-		// Retrieve the stored address
-		final SharedPreferences settings = PreferenceManager
-				.getDefaultSharedPreferences(parentContext);
-		String address = settings.getString(
-				Constants.PREF_BLUETOOTH_DEVICE_ADDRESS, null);
+        //Retrieve the stored device
+        BluetoothDevice device = null;
+        final SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(parentContext);
+        final String addressName = settings.getString(Constants.PREF_BLUETOOTH_DEVICE_ADDRESS, null);
 
-		BluetoothDevice device = address == null ? findSerialBluetoothBoard()
-				: mBluetoothAdapter.getRemoteDevice(address);
+        if (addressName != null) {
+            // strip name, use address part - stored as <address>;<name>
+            final String part[] = addressName.split(";");
+            try {
+                device = mBluetoothAdapter.getRemoteDevice(part[0]);
+            } catch (IllegalArgumentException ex) {
+                // invalid configuration (device may have been removed)
+                // NOP fall through to 'no device'
+            }
+        }
+        // no device
+        if(device == null)
+            device = findSerialBluetoothBoard();
 
-		Log.d(BLUE,
+        Log.d(BLUE,
 				"Trying to connect to device with address "
 						+ device.getAddress());
 		Log.d(BLUE, "BT Create Socket Call...");

--- a/Android/src/org/droidplanner/android/fragments/SettingsFragment.java
+++ b/Android/src/org/droidplanner/android/fragments/SettingsFragment.java
@@ -195,6 +195,7 @@ public class SettingsFragment extends DpPreferenceFragment implements
         mDefaultSummaryPrefs.add(getString(R.string.pref_server_port_key));
         mDefaultSummaryPrefs.add(getString(R.string.pref_server_ip_key));
         mDefaultSummaryPrefs.add(getString(R.string.pref_udp_server_port_key));
+        mDefaultSummaryPrefs.add(getString(R.string.pref_bluetooth_device_address_key));
         mDefaultSummaryPrefs.add(getString(R.string.pref_vehicle_type_key));
         mDefaultSummaryPrefs.add(getString(R.string.pref_rc_quickmode_left_key));
         mDefaultSummaryPrefs.add(getString(R.string.pref_rc_quickmode_right_key));

--- a/Android/src/org/droidplanner/android/fragments/helpers/BTDeviceListFragment.java
+++ b/Android/src/org/droidplanner/android/fragments/helpers/BTDeviceListFragment.java
@@ -157,8 +157,9 @@ public class BTDeviceListFragment extends DialogFragment {
 			final Activity activity = getActivity();
 			final SharedPreferences.Editor editor = PreferenceManager
 					.getDefaultSharedPreferences(activity).edit();
-			editor.putString(Constants.PREF_BLUETOOTH_DEVICE_ADDRESS,
-					device.getAddress()).apply();
+            editor.putString(Constants.PREF_BLUETOOTH_DEVICE_ADDRESS,
+                    device.getAddress() + ";" + device.getName())
+                    .apply();
 
 			// Toggle the drone connection
 			((DroidPlannerApp) activity.getApplication()).getDrone().MavClient


### PR DESCRIPTION
... until reset by clearing Settings-> Connection Preferences -> Bluetooth Device

Don't prompt for BT device selection once set (until reset / forgotten).
Ease of use enhancement.

![screenshot_2014-07-08-10-37-42](https://cloud.githubusercontent.com/assets/4014433/3511238/10f23c58-06ae-11e4-9051-c33f4b08f1a9.png)
