### PR TITLE
Parameters: fix for dup parameters after writing updated params to AC v3.2

### DIFF
--- a/Android/src/org/droidplanner/android/widgets/adapterViews/ParamsAdapter.java
+++ b/Android/src/org/droidplanner/android/widgets/adapterViews/ParamsAdapter.java
@@ -18,6 +18,7 @@ import android.content.Context;
 import android.graphics.Color;
 import android.text.Editable;
 import android.text.TextWatcher;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -134,10 +135,13 @@ public class ParamsAdapter extends ArrayAdapter<ParamsAdapterItem> {
 
 	private void addParameter(Parameter parameter) {
 		try {
-			Parameter.checkParameterName(parameter.name);
-			add(new ParamsAdapterItem(parameter, getMetadata(parameter.name)));
+            Parameter.checkParameterName(parameter.name);
 
-		} catch (Exception ex) {
+            // paramters from AC 3.2 may contain duplicates - add only if unique
+            if(!containsParameterWithName(parameter.name))
+                add(new ParamsAdapterItem(parameter, getMetadata(parameter.name)));
+
+        } catch (Exception ex) {
 			// eat it
 		}
 	}
@@ -151,6 +155,16 @@ public class ParamsAdapter extends ArrayAdapter<ParamsAdapterItem> {
 		}
 		notifyDataSetChanged();
 	}
+
+    private boolean containsParameterWithName(String name)
+    {
+        final int count = getCount();
+        for(int i = 0; i < count; i++) {
+            if (name.equals(getItem(i).getParameter().name))
+                return true;
+        }
+        return false;
+    }
 
 	private void loadMetadataInternal(Drone drone) {
 		metadataMap = null;


### PR DESCRIPTION
Parameter collection received from vehicle after writing updating parameters can contain duplicates w/ AC v3.2 (e.g. FS_THR_ENABLE below). Fixed by adding simple uniqueness check when populating parameter adapter.
![screenshot_2014-07-15-00-21-52](https://cloud.githubusercontent.com/assets/4014433/3580599/760221aa-0bd9-11e4-9f15-1f9b2b5d6987.png)
