### PR TITLE
Fix a bug where ATTITUDE messages were not causing the attitude display to update

### DIFF
--- a/Android/src/org/droidplanner/android/fragments/TelemetryFragment.java
+++ b/Android/src/org/droidplanner/android/fragments/TelemetryFragment.java
@@ -70,7 +70,7 @@ public class TelemetryFragment extends Fragment implements OnDroneListener {
 		switch (event) {
 		case NAVIGATION:
 			break;
-		case ORIENTATION:
+		case ATTITUDE:
 			onOrientationUpdate(drone);
 			break;
 		case SPEED:

--- a/Core/src/org/droidplanner/core/drone/DroneInterfaces.java
+++ b/Core/src/org/droidplanner/core/drone/DroneInterfaces.java
@@ -39,7 +39,7 @@ public class DroneInterfaces {
 		/**
          *
          */
-		ATTIUTDE,
+		ATTITUDE,
 
 		/**
          *

--- a/Core/src/org/droidplanner/core/drone/variables/Orientation.java
+++ b/Core/src/org/droidplanner/core/drone/variables/Orientation.java
@@ -29,7 +29,7 @@ public class Orientation extends DroneVariable {
 		this.roll = roll;
 		this.pitch = pitch;
 		this.yaw = yaw;
-		myDrone.events.notifyDroneEvent(DroneEventsType.ATTIUTDE);
+		myDrone.events.notifyDroneEvent(DroneEventsType.ATTITUDE);
 	}
 
 }


### PR DESCRIPTION
I posted about this being broken for the AR Drone on the google+ group.  Turns out the issue was a simple bug caused by confusion between the ATTITUDE and ORIENTATION events.
The attitude display was not updating until an (unrelated) ORIENTATION event was received:
Correct spelling of ATTITUDE event.
Correct  misuse of ORIENTATION event where ATTITUDE was needed.
