### PR TITLE
Fix flight actions state

### DIFF
--- a/Android/src/org/droidplanner/android/fragments/FlightActionsFragment.java
+++ b/Android/src/org/droidplanner/android/fragments/FlightActionsFragment.java
@@ -165,8 +165,7 @@ public class FlightActionsFragment extends Fragment implements OnClickListener, 
 
 		case ARMING:
 
-			int visibility = (drone.state.isArmed() && !drone.state
-					.isFailsafe()) ? View.VISIBLE : View.GONE;
+			int visibility = (drone.state.isArmed()) ? View.VISIBLE : View.GONE;
 			setFlyingActionsVisibility(visibility);
 			break;
 		case MODE:


### PR DESCRIPTION
Closes https://github.com/DroidPlanner/droidplanner/issues/856

Changes:
- All buttons (except Edit) in FlightActionsFragment are shown/hidden based on isArmed() && !isFailsafe()
- As Loiter, Home and Land buttons are just shortcuts of corresponding modes, when clicked, they become disabled, and when mode is changed, enabled

TODO:
- [ ] Prepare drawables for disabled state of buttons in FlightActionsFragment
- [x] Hide or disable buttons? A: Look Changes
