### PR TITLE
Fix path for the Core project

### DIFF
--- a/Android/.classpath
+++ b/Android/.classpath
@@ -5,5 +5,7 @@
 	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.DEPENDENCIES"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="gen"/>
+	<classpathentry kind="src" path="/Core"/>
+	<classpathentry kind="src" path="/Mavlink"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>

--- a/Android/project.properties
+++ b/Android/project.properties
@@ -14,7 +14,5 @@
 target=android-19
 android.library.reference.1=../usb-serial-for-android/UsbSerialLibrary
 android.library.reference.2=../HorizontalVariableListView/HorizontalVariableListView
-android.library.reference.3=../Mavlink
-android.library.reference.4=../Core
-android.library.reference.5=../google-play-services_lib
-android.library.reference.6=../PebbleKit
+android.library.reference.3=../google-play-services_lib
+android.library.reference.4=../PebbleKit


### PR DESCRIPTION
This makes the Android project link to the source of the Core project instead of the compiled jar.
