### PR TITLE
Fix eclipse build

### DIFF
--- a/Android/project.properties
+++ b/Android/project.properties
@@ -14,5 +14,7 @@
 target=android-19
 android.library.reference.1=../usb-serial-for-android/UsbSerialLibrary
 android.library.reference.2=../HorizontalVariableListView/HorizontalVariableListView
-android.library.reference.3=../google-play-services_lib
-android.library.reference.4=../PebbleKit
+android.library.reference.3=../Mavlink
+android.library.reference.4=../Core
+android.library.reference.5=../google-play-services_lib
+android.library.reference.6=../PebbleKit


### PR DESCRIPTION
When building with the eclipse the app would be creeated as desired, but would crash when trying to open in a real device. This fix this issue, but it makes CORE project not reachable via the eclipse navigation tools anymore as was done in #939.
