### PR TITLE
NullPointer Exception fix on Editor

### DIFF
--- a/Android/src/org/droidplanner/android/fragments/EditorToolsFragment.java
+++ b/Android/src/org/droidplanner/android/fragments/EditorToolsFragment.java
@@ -46,7 +46,7 @@ public class EditorToolsFragment extends Fragment implements OnClickListener, On
 
 	private OnEditorToolSelected listener;
 	private RadioGroup mEditorRadioGroup;
-	private EditorTools tool;
+	private EditorTools tool = EditorTools.NONE;
 	private MissionProxy mMissionProxy;
 
 	@Override


### PR DESCRIPTION
When opening the editor with a loaded mission a null pointer exception was being generated. This fixes the problem.
