### PR TITLE
Change failsafe message to be more generic

### DIFF
--- a/Core/src/org/droidplanner/core/MAVLink/MavLinkMsgHandler.java
+++ b/Core/src/org/droidplanner/core/MAVLink/MavLinkMsgHandler.java
@@ -114,7 +114,7 @@ public class MavLinkMsgHandler {
 	private void checkFailsafe(msg_heartbeat msg_heart) {
 		boolean failsafe2 = msg_heart.system_status == (byte) MAV_STATE.MAV_STATE_CRITICAL;
 		if(failsafe2){
-			drone.state.setFailsafe("RC Failsafe");
+			drone.state.setFailsafe("Failsafe");
 		}
 	}
 


### PR DESCRIPTION
Since the MAV_STATE_CRITICAL bit is set for any fail-safe type the message must be more generic.c
https://github.com/diydrones/ardupilot/blob/d130f0c4994f5e33f07364be8e4972adfd1fa723/ArduCopter/GCS_Mavlink.pde#L48-L51

This relates to #978
