### PR TITLE
modify defaultvalue of tts periodic period

### DIFF
--- a/Android/res/xml/preferences.xml
+++ b/Android/res/xml/preferences.xml
@@ -81,7 +81,7 @@
                     android:entryValues="@array/tts_periodic_period_values"
                     android:key="@string/pref_tts_periodic_period_key"
                     android:summary="@string/pref_tts_periodic_period_summary"
-                    android:defaultValue="off"/>
+                    android:defaultValue="0"/>
                 <CheckBoxPreference
                     android:title="@string/pref_tts_periodic_bat_volt"
                     android:key="@string/pref_tts_periodic_bat_volt_key"


### PR DESCRIPTION
modify defaultvalue of tts periodic period from "off" to "0"
1. string "off" causes parseInt() throwing an exception while calling function
"getSpokenStatusInterval"
