### PR TITLE
Core: Log messages after sending them to the app

### DIFF
--- a/Core/src/org/droidplanner/core/MAVLink/connection/MavLinkConnection.java
+++ b/Core/src/org/droidplanner/core/MAVLink/connection/MavLinkConnection.java
@@ -127,9 +127,9 @@ public abstract class MavLinkConnection {
             for (int i = 0; i < bufferSize; i++) {
                 MAVLinkPacket receivedPacket = parser.mavlink_parse_char(buffer[i] & 0x00ff);
                 if (receivedPacket != null) {
-                    queueToLog(receivedPacket);
                     MAVLinkMessage msg = receivedPacket.unpack();
                     reportReceivedMessage(msg);
+                    queueToLog(receivedPacket);
                 }
             }
         }


### PR DESCRIPTION
The queueToLog() method was consuming the fields of some of the messages and the app was receiving incorrectly parsed messages.

This closes #1050
