### PR TITLE
Follow: Fix forgotten implementation of Location class.

### DIFF
--- a/Android/src/org/droidplanner/android/gcs/location/FusedLocation.java
+++ b/Android/src/org/droidplanner/android/gcs/location/FusedLocation.java
@@ -69,7 +69,7 @@ public class FusedLocation implements LocationFinder, GooglePlayServicesClient.C
 		if (receiver != null) {
 			org.droidplanner.core.gcs.location.Location location = new org.droidplanner.core.gcs.location.Location(
 					new Coord2D(androidLocation.getLatitude(), androidLocation.getLongitude()),
-					androidLocation.getAccuracy());
+					androidLocation.getAccuracy(),androidLocation.getBearing(),androidLocation.getSpeed());
 			receiver.onLocationChanged(location);
 		}
 	}

--- a/Core/src/org/droidplanner/core/gcs/location/Location.java
+++ b/Core/src/org/droidplanner/core/gcs/location/Location.java
@@ -25,9 +25,11 @@ public class Location {
 		coordinate = coord2d;
 	}
 
-	public Location(Coord2D coord2d, double accuracy) {
+	public Location(Coord2D coord2d, double accuracy, float heading, float speed) {
 		coordinate = coord2d;
 		this.accuracy = accuracy;
+		this.heading = heading;
+		this.speed = speed;
 	}
 
 	public Coord2D getCoord() {


### PR DESCRIPTION
During the refactor of FusedLocation both the heading and speed have not been passed from the fusedLocation to the location object.

This was causing follow me in any of the "heading type" of follow me to misbehave.
