### PR TITLE
CameraInfo: Adding a file with info for the GoPro Hero 4

### DIFF
--- a/Android/assets/CameraInfo/GoPro Hero 4 Black.xml
+++ b/Android/assets/CameraInfo/GoPro Hero 4 Black.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<cameraInfo>
+    <Name>GoPro Hero 4 Black</Name>
+    <SensorWidth>6.17</SensorWidth>
+    <SensorHeight>4.55</SensorHeight>
+    <SensorResolution>12.0</SensorResolution>
+    <FocalLength>14</FocalLength>
+</cameraInfo>


### PR DESCRIPTION
From what I was able to find out it's the same as the GoPro Hero 3+ Black
