### PR TITLE
PX4 does not listen to MAV_COMP_ID_SYSTEM_CONTROL

### DIFF
--- a/Core/src/org/droidplanner/core/MAVLink/MavLinkArm.java
+++ b/Core/src/org/droidplanner/core/MAVLink/MavLinkArm.java
@@ -11,7 +11,7 @@ public class MavLinkArm {
 	public static void sendArmMessage(Drone drone, boolean arm) {
 		msg_command_long msg = new msg_command_long();
 		msg.target_system = drone.getSysid();
-		msg.target_component = (byte) MAV_COMPONENT.MAV_COMP_ID_SYSTEM_CONTROL;
+		msg.target_component = drone.getCompid();
 
 		msg.command = MAV_CMD.MAV_CMD_COMPONENT_ARM_DISARM;
 		msg.param1 = arm ? 1 : 0;


### PR DESCRIPTION
PX4 only listen to its own component id and not MAV_COMP_ID_SYSTEM_CONTROL.
I have searched in almost any type of autopilot firmware including ardupilot and it seems that they all accept MAV_CMD with there drone component id and not MAV_COMP_ID_SYSTEM_CONTROL.
But to be honest I'm not quiet sure, before merging we should check this with people using different autopilots.
