### PR TITLE
Feature add kill switch

### DIFF
--- a/Android/res/menu/menu_super_activiy.xml
+++ b/Android/res/menu/menu_super_activiy.xml
@@ -21,6 +21,22 @@
             app:showAsAction="never"
             android:title="@string/download_mission"/>
 
+        <item
+            android:id="@+id/menu_advanced"
+            android:enabled="false"
+            android:visible="false"
+            android:title="@string/pref_advanced"
+            app:showAsAction="never">
+            <menu>
+                <item
+                    android:id="@+id/menu_kill_switch"
+                    app:showAsAction="never"
+                    android:enabled="false"
+                    android:visible="false"
+                    android:title="KILL SWITCH"/>
+            </menu>
+        </item>
+
     </group>
 
 </menu>

--- a/Android/res/values/preferences_keys.xml
+++ b/Android/res/values/preferences_keys.xml
@@ -59,5 +59,6 @@ This file is used to store the preferences keys so that it's accessible and modi
     <string name="pref_ground_collision_warning_key" translatable="false">pref_ground_collision_warning</string>
 
     <string name="pref_unit_system_key" translatable="false">pref_unit_system</string>
+    <string name="pref_enable_kill_switch_key" translatable="false">pref_enable_kill_switch</string>
 
 </resources>

--- a/Android/res/values/strings.xml
+++ b/Android/res/values/strings.xml
@@ -542,5 +542,8 @@
     <string name="pref_ground_collision_warning_summary">Warns about imminent ground collision.</string>
     <string name="pref_map_rotation_title">Enable map rotation</string>
     <string name="pref_map_rotation_summary">Check to enable the ability to rotate the map.</string>
+    <string name="pref_advance_menu_title">Advanced Menu Options</string>
+    <string name="pref_enable_kill_switch_summary">If enabled, a Kill Switch option will appear under the Advanced section in the menu, allowing to disarm the vehicle immediately.</string>
+    <string name="pref_enable_kill_switch_title">Enable Kill Switch</string>
 
 </resources>

--- a/Android/res/xml/preferences.xml
+++ b/Android/res/xml/preferences.xml
@@ -259,6 +259,17 @@
                     android:summary="@string/pref_ui_gps_hdop_summary"
                     android:title="@string/pref_ui_gps_hdop_title" />
             </PreferenceCategory>
+
+            <PreferenceCategory
+                android:title="@string/pref_advance_menu_title">
+
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:key="@string/pref_enable_kill_switch_key"
+                    android:summary="@string/pref_enable_kill_switch_summary"
+                    android:title="@string/pref_enable_kill_switch_title"/>
+
+            </PreferenceCategory>
         </PreferenceScreen>
     </PreferenceCategory>
 

--- a/Android/src/org/droidplanner/android/activities/helpers/SuperUI.java
+++ b/Android/src/org/droidplanner/android/activities/helpers/SuperUI.java
@@ -9,7 +9,6 @@ import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.v4.app.NavUtils;
 import android.support.v4.content.LocalBroadcastManager;
-import android.support.v7.app.ActionBarActivity;
 import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -257,7 +256,7 @@ public abstract class SuperUI extends AppCompatActivity implements DroidPlannerA
                     public void run() {
                         dpApp.getDrone().arm(false);
                     }
-                }) ;
+                });
                 unlockDialog.show(getSupportFragmentManager(), "Slide to use the Kill Switch");
                 return true;
 

--- a/Android/src/org/droidplanner/android/fragments/SettingsFragment.java
+++ b/Android/src/org/droidplanner/android/fragments/SettingsFragment.java
@@ -79,6 +79,8 @@ public class SettingsFragment extends PreferenceFragment implements OnSharedPref
     public static final String ACTION_LOCATION_SETTINGS_UPDATED = PACKAGE_NAME + ".action.LOCATION_SETTINGS_UPDATED";
     public static final String EXTRA_RESULT_CODE = "extra_result_code";
 
+    public static final String ACTION_ADVANCED_MENU_UPDATED = PACKAGE_NAME + ".action.ADVANCED_MENU_UPDATED";
+
     /**
      * Used to notify of an update to the map rotation preference.
      */
@@ -254,6 +256,16 @@ public class SettingsFragment extends PreferenceFragment implements OnSharedPref
             @Override
             public boolean onPreferenceChange(Preference preference, Object newValue) {
                 lbm.sendBroadcast(new Intent(ACTION_PREF_HDOP_UPDATE));
+                return true;
+            }
+        });
+
+        final CheckBoxPreference killSwitch = (CheckBoxPreference) findPreference(getString(R.string
+                .pref_enable_kill_switch_key));
+        killSwitch.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                lbm.sendBroadcast(new Intent(ACTION_ADVANCED_MENU_UPDATED));
                 return true;
             }
         });

--- a/Android/src/org/droidplanner/android/utils/prefs/DroidPlannerPrefs.java
+++ b/Android/src/org/droidplanner/android/utils/prefs/DroidPlannerPrefs.java
@@ -50,6 +50,7 @@ public class DroidPlannerPrefs {
     private static final int DEFAULT_UNIT_SYSTEM = UnitSystem.AUTO;
     private static final boolean DEFAULT_WARNING_GROUND_COLLISION = false;
     private static final boolean DEFAULT_ENABLE_MAP_ROTATION = true;
+    private static final boolean DEFAULT_ENABLE_KILL_SWITCH = false;
 
     // Public for legacy usage
 	public SharedPreferences prefs;
@@ -347,5 +348,13 @@ public class DroidPlannerPrefs {
 
     public boolean isMapRotationEnabled(){
         return prefs.getBoolean(context.getString(R.string.pref_map_enable_rotation_key), DEFAULT_ENABLE_MAP_ROTATION);
+    }
+
+    public boolean isAdvancedMenuEnabled(){
+        return isKillSwitchEnabled();
+    }
+
+    public boolean isKillSwitchEnabled(){
+        return prefs.getBoolean(context.getString(R.string.pref_enable_kill_switch_key), DEFAULT_ENABLE_KILL_SWITCH);
     }
 }


### PR DESCRIPTION
Fixes issue #1433 

Kill switch option can be enabled through `Settings` -> `Advanced` -> `Enable KILL SWITCH`.
After being enabled, it's available in the overflow menu, under the `Advanced` section.