### PR TITLE
fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,6 @@ before_script:
     - echo yes | android update sdk -u -a -t extra-google-m2repository
     - echo yes | android update sdk -u -a -t extra-android-m2repository
     - echo yes | android update sdk -u -a -t extra-android-support,extra-google-google_play_services
+    - export GRADLE_OPTS="-XX:MaxPermSize=128m"
 
 script: ./gradlew build


### PR DESCRIPTION
Not sure if this will work...

`:Android:Lint` is throwing an error.  The fix is to give lint more permspace with `-XX:MaxPermSize=256m`.  I'm just not sure where to put it.  Alternatively, just disable lint.