### PR TITLE
Settings: Fix Layout for clarity in setting USB,UDP,TCP settings

### DIFF
--- a/Android/res/values/strings.xml
+++ b/Android/res/values/strings.xml
@@ -40,6 +40,7 @@
     <string name="pref_enable_tts_summary">Audible messages for important events</string>
     <string name="pref_request_max_volume">Set Volume To Max On Start</string>
     <string name="pref_connection">Connection Preferences</string>
+    <string name="pref_connection_subtitle">USB, TCP and UDP settings</string>
     <string name="pref_usb">USB Connection</string>
     <string name="pref_baud_type">Telemetry link speed</string>
     <string name="pref_baud_type_summary">Baud Rate of the USB Telemetry Link</string>

--- a/Android/res/xml/preferences.xml
+++ b/Android/res/xml/preferences.xml
@@ -189,9 +189,10 @@
         <PreferenceScreen
             android:key="pref_advanced"
             android:title="@string/pref_advanced" >
+            <PreferenceCategory android:title="@string/pref_connection">
             <PreferenceScreen
                 android:key="pref_connection"
-                android:title="@string/pref_connection" >
+                android:title="@string/pref_connection_subtitle" >
                 <PreferenceCategory
                     android:key="pref_usb"
                     android:title="@string/pref_usb" >
@@ -262,6 +263,7 @@
                         android:title="@string/pref_forget_bluetooth_device_address" />
                 </PreferenceCategory>
             </PreferenceScreen>
+            </PreferenceCategory>
 
             <PreferenceCategory
                 android:title="@string/pref_alt_title">


### PR DESCRIPTION
Not big fix, but one that drove me slightly mad in the past and RobL just yesterday. This adds some visual clarity to the Advanced Preferences view, by having a **Connection Preferences** category title and a **USB, TCP, UDP Settings** clickable option. In the old layout it just looked like a title. And was easily missed

(I made the change against the beta, as it's small change)

![fix menu item](https://cloud.githubusercontent.com/assets/959994/9869261/09826cf2-5b37-11e5-8941-c5163b42aa56.png)