### PR TITLE
Navigation Drawer color fix for text and icons - Android 8.0 (API level 26)

### DIFF
--- a/Android/res/layout/activity_drawer_navigation_ui.xml
+++ b/Android/res/layout/activity_drawer_navigation_ui.xml
@@ -64,7 +64,9 @@
             android:layout_width="wrap_content"
             android:layout_height="0dp"
             android:layout_weight="1"
-            app:menu="@menu/navigation_drawer_items" />
+            app:menu="@menu/navigation_drawer_items"
+            app:itemIconTint="@color/grey"
+            app:itemTextColor="@color/black_text"/>
 
         <View
             android:layout_width="match_parent"
@@ -75,6 +77,8 @@
             android:id="@+id/navigation_drawer_settings"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:menu="@menu/navigation_drawer_settings"/>
+            app:menu="@menu/navigation_drawer_settings"
+            app:itemIconTint="@color/grey"
+            app:itemTextColor="@color/black_text"/>
     </LinearLayout>
 </android.support.v4.widget.DrawerLayout>

--- a/Android/res/values/colors.xml
+++ b/Android/res/values/colors.xml
@@ -5,6 +5,7 @@
     <color name="transparent_light">#90ffffff</color>
     <color name="opaque_white">#fff</color>
     <color name="greyText">#5d5d5d</color>
+    <color name="grey">#5d5d5d</color>
     <color name="dark_grey">#9E9E9E</color>
     <color name="transparent_light_grey">#d0EFEFEF</color>
     <color name="light_grey">#EFEFEF</color>


### PR DESCRIPTION
Issue --> https://github.com/DroidPlanner/Tower/issues/1871

No color has been defined for the text and the icons in the navigation drawer which caused the issue with the color of the text and icons in Android 8. So, added the default color for text and icons.