### PR TITLE
Discontinue old API used for Mapbox projects/classic, replace with Mapbox Studio styled raster tiles

### DIFF
--- a/Android/AndroidManifest.xml
+++ b/Android/AndroidManifest.xml
@@ -59,7 +59,7 @@
         <!-- You must insert your own Google Maps for Android API v2 key in here. -->
         <meta-data
             android:name="com.google.android.maps.v2.API_KEY"
-            android:value="AIzaSyDIqKWHqt4rWiIG_QJZXBAQBKHCbmU-lqI"/>
+            android:value="AddYourOwnKeyFromGoogleCloudPlatformHere"/>
         <meta-data
             android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version"/>

--- a/Android/AndroidManifest.xml
+++ b/Android/AndroidManifest.xml
@@ -59,7 +59,7 @@
         <!-- You must insert your own Google Maps for Android API v2 key in here. -->
         <meta-data
             android:name="com.google.android.maps.v2.API_KEY"
-            android:value="AIzaSyA2oC6zsx-Ir4be8bWFWrAej7FcKdrWGdA"/>
+            android:value="AIzaSyDIqKWHqt4rWiIG_QJZXBAQBKHCbmU-lqI"/>
         <meta-data
             android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version"/>

--- a/Android/build.gradle
+++ b/Android/build.gradle
@@ -49,10 +49,10 @@ dependencies {
     //Charts and graph library
     compile 'com.github.lecho:hellocharts-library:1.5.5@aar'
 
-    //Leak canary (https://github.com/square/leakcanary)
+    /*Leak canary (https://github.com/square/leakcanary)
     debugCompile 'com.squareup.leakcanary:leakcanary-android:1.4-beta2'
     releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.4-beta2'
-    testCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.4-beta2'
+    testCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.4-beta2' */
 }
 
 def versionPrefix = "Tower-v"

--- a/Android/res/values/strings.xml
+++ b/Android/res/values/strings.xml
@@ -448,9 +448,12 @@
     <string name="pref_title_mapbox_tile_provider">Mapbox Tile Provider</string>
     <string name="pref_title_mapbox_map_download">Download Offline Map</string>
     <string name="pref_summary_mapbox_map_download">Click to cache map for use while offline</string>
+    <string name="pref_title_mapbox_Userid">Mapbox UserId</string>
+    <string name="pref_hint_mapbox_Userid">Mapbox user id</string>
+    <string name="pref_summary_mapbox_Userid">Enter your mapbox user id</string>
     <string name="pref_title_mapbox_id">Mapbox Id</string>
     <string name="pref_hint_mapbox_id">Mapbox map id</string>
-    <string name="pref_summary_mapbox_id">Enter your mapbox map id</string>
+    <string name="pref_summary_mapbox_id">Enter your mapbox styled map id</string>
     <string name="pref_title_mapbox_access_token">Mapbox Access Token</string>
     <string name="pref_hint_mapbox_access_token">Mapbox access token</string>
     <string name="pref_summary_mapbox_access_token">Enter your mapbox access token</string>
@@ -461,6 +464,7 @@
     <string name="instructions_map_download_selection">Pan and zoom to adjust the map area to save</string>
     <string name="instructions_tap_to_save_map">Tap to save the map</string>
     <string name="label_map_saved">Map area saved!</string>
+    <string name="label_invalid_mapbox_userid">Invalid mapbox user id</string>
     <string name="label_invalid_mapbox_id">Invalid mapbox id</string>
     <string name="label_invalid_mapbox_access_token">Invalid mapbox access token</string>
     <string name="alert_invalid_mapbox_credentials">Invalid mapbox credentials! Please update your mapbox settings.</string>

--- a/Android/res/xml/preferences_google_maps.xml
+++ b/Android/res/xml/preferences_google_maps.xml
@@ -78,6 +78,14 @@
 
             <EditTextPreference
                 android:gravity="center"
+                android:hint="@string/pref_hint_mapbox_Userid"
+                android:key="pref_mapbox_userid"
+                android:selectAllOnFocus="true"
+                android:summary="@string/pref_summary_mapbox_Userid"
+                android:title="@string/pref_title_mapbox_Userid"/>
+
+            <EditTextPreference
+                android:gravity="center"
                 android:hint="@string/pref_hint_mapbox_id"
                 android:key="pref_mapbox_id"
                 android:selectAllOnFocus="true"

--- a/Android/src/org/droidplanner/android/DroidPlannerApp.java
+++ b/Android/src/org/droidplanner/android/DroidPlannerApp.java
@@ -162,11 +162,12 @@ public class DroidPlannerApp extends MultiDexApplication implements DroneListene
         lbm = LocalBroadcastManager.getInstance(context);
         soundManager = new SoundManager(context);
 
-        initLoggingAndAnalytics();
+        /*initLoggingAndAnalytics();*/
         initDronekit();
         initDatabases();
     }
 
+    /*
     private void initLoggingAndAnalytics(){
         //Init leak canary
         LeakCanary.install(this);
@@ -195,6 +196,7 @@ public class DroidPlannerApp extends MultiDexApplication implements DroneListene
             Fabric.with(context, new Crashlytics());
         }
     }
+    */
 
     private void initDronekit(){
         Context context = getApplicationContext();

--- a/Android/src/org/droidplanner/android/DroidPlannerApp.java
+++ b/Android/src/org/droidplanner/android/DroidPlannerApp.java
@@ -26,7 +26,6 @@ import com.o3dr.services.android.lib.drone.connection.ConnectionParameter;
 import com.o3dr.services.android.lib.drone.connection.ConnectionType;
 import com.o3dr.services.android.lib.gcs.link.LinkConnectionStatus;
 import com.o3dr.services.android.lib.model.AbstractCommandListener;
-import com.squareup.leakcanary.LeakCanary;
 
 import org.droidplanner.android.activities.helpers.BluetoothDevicesActivity;
 import org.droidplanner.android.droneshare.UploaderService;

--- a/Android/src/org/droidplanner/android/maps/GoogleMapFragment.java
+++ b/Android/src/org/droidplanner/android/maps/GoogleMapFragment.java
@@ -1233,11 +1233,13 @@ public class GoogleMapFragment extends SupportMapFragment implements DPMap,
         map.setMapType(GoogleMap.MAP_TYPE_NORMAL);
 
         final GoogleMapPrefFragment.PrefManager prefManager = GoogleMapPrefFragment.PrefManager;
+        final String mapboxUserId = prefManager.getMapboxUserId(context);
         final String mapboxId = prefManager.getMapboxId(context);
         final String mapboxAccessToken = prefManager.getMapboxAccessToken(context);
         final int maxZoomLevel = (int) map.getMaxZoomLevel();
 
         if (!(tileProviderManager instanceof MapboxTileProviderManager)
+                || !mapboxUserId.equals(((MapboxTileProviderManager) tileProviderManager).getMapboxUserId())
             || !mapboxId.equals(((MapboxTileProviderManager) tileProviderManager).getMapboxId())
             || !mapboxAccessToken.equals(((MapboxTileProviderManager) tileProviderManager).getMapboxAccessToken())) {
 
@@ -1247,7 +1249,7 @@ public class GoogleMapFragment extends SupportMapFragment implements DPMap,
                 onlineTileOverlay = null;
             }
 
-            tileProviderManager = new MapboxTileProviderManager(context, mapboxId, mapboxAccessToken, maxZoomLevel);
+            tileProviderManager = new MapboxTileProviderManager(context, mapboxUserId, mapboxId, mapboxAccessToken, maxZoomLevel);
             TileOverlayOptions options = new TileOverlayOptions()
                 .tileProvider(tileProviderManager.getOnlineTileProvider())
                 .zIndex(ONLINE_TILE_PROVIDER_Z_INDEX);
@@ -1275,7 +1277,7 @@ public class GoogleMapFragment extends SupportMapFragment implements DPMap,
             @Override
             protected Integer doInBackground(Void... params) {
                 final Context context = getContext();
-                return MapboxUtils.fetchReferenceTileUrl(context, mapboxId, mapboxAccessToken);
+                return MapboxUtils.fetchReferenceTileUrl(context, mapboxUserId, mapboxId, mapboxAccessToken);
             }
 
             @Override

--- a/Android/src/org/droidplanner/android/maps/providers/google_map/tiles/mapbox/MapboxTileProvider.java
+++ b/Android/src/org/droidplanner/android/maps/providers/google_map/tiles/mapbox/MapboxTileProvider.java
@@ -14,12 +14,14 @@ public class MapboxTileProvider extends UrlTileProvider {
 
     private final static String TAG = MapboxTileProvider.class.getSimpleName();
 
+    private final String mapboxUserId;
     private final String mapboxId;
     private final String mapboxAccessToken;
     private final int maxZoomLevel;
 
-    public MapboxTileProvider(String mapboxId, String mapboxAccessToken, int maxZoomLevel) {
+    public MapboxTileProvider(String mapboxUserId, String mapboxId, String mapboxAccessToken, int maxZoomLevel) {
         super(MapboxUtils.TILE_WIDTH, MapboxUtils.TILE_HEIGHT);
+        this.mapboxUserId = mapboxUserId;
         this.mapboxId = mapboxId;
         this.mapboxAccessToken = mapboxAccessToken;
         this.maxZoomLevel = maxZoomLevel;
@@ -28,7 +30,7 @@ public class MapboxTileProvider extends UrlTileProvider {
     @Override
     public URL getTileUrl(int x, int y, int zoom) {
         if (zoom <= maxZoomLevel) {
-            final String tileUrl = MapboxUtils.getMapTileURL(mapboxId, mapboxAccessToken, zoom, x, y);
+            final String tileUrl = MapboxUtils.getMapTileURL(mapboxUserId, mapboxId, mapboxAccessToken, zoom, x, y);
             try {
                 return new URL(tileUrl);
             } catch (MalformedURLException e) {
@@ -44,5 +46,9 @@ public class MapboxTileProvider extends UrlTileProvider {
 
     public String getMapboxId() {
         return mapboxId;
+    }
+
+    public String getMapboxUserId() {
+        return mapboxUserId;
     }
 }

--- a/Android/src/org/droidplanner/android/maps/providers/google_map/tiles/mapbox/MapboxTileProviderManager.java
+++ b/Android/src/org/droidplanner/android/maps/providers/google_map/tiles/mapbox/MapboxTileProviderManager.java
@@ -37,16 +37,22 @@ public class MapboxTileProviderManager extends TileProviderManager {
     private final Handler handler = new Handler();
 
     private final Context context;
+    private final String mapboxUserId;
     private final String mapboxId;
     private final String mapboxAccessToken;
 
-    public MapboxTileProviderManager(Context context, String mapboxId, String mapboxAccessToken, int maxZoomLevel) {
-        super(new MapboxTileProvider(mapboxId, mapboxAccessToken, maxZoomLevel),
-            new OfflineTileProvider(context, mapboxId, mapboxAccessToken, maxZoomLevel));
+    public MapboxTileProviderManager(Context context, String mapboxUserId, String mapboxId, String mapboxAccessToken, int maxZoomLevel) {
+        super(new MapboxTileProvider(mapboxUserId, mapboxId, mapboxAccessToken, maxZoomLevel),
+            new OfflineTileProvider(context, mapboxUserId, mapboxId, mapboxAccessToken, maxZoomLevel));
 
         this.context = context;
+        this.mapboxUserId = mapboxUserId;
         this.mapboxId = mapboxId;
         this.mapboxAccessToken = mapboxAccessToken;
+    }
+
+    public String getMapboxUserId() {
+        return mapboxUserId;
     }
 
     public String getMapboxAccessToken() {
@@ -60,15 +66,15 @@ public class MapboxTileProviderManager extends TileProviderManager {
     @Override
     public void downloadMapTiles(MapDownloader mapDownloader, DPMap.VisibleMapArea mapRegion, int
         minimumZ, int maximumZ) {
-        beginDownloadingMapID(mapDownloader, this.mapboxId, this.mapboxAccessToken, mapRegion, minimumZ, maximumZ);
+        beginDownloadingMapID(mapDownloader, this.mapboxUserId, this.mapboxId, this.mapboxAccessToken, mapRegion, minimumZ, maximumZ);
     }
 
-    private void beginDownloadingMapID(final MapDownloader mapDownloader, final String mapId, final String accessToken, DPMap.VisibleMapArea mapRegion, int
+    private void beginDownloadingMapID(final MapDownloader mapDownloader, final String userId, final String mapId, final String accessToken, DPMap.VisibleMapArea mapRegion, int
         minimumZ, int maximumZ) {
-        beginDownloadingMapID(mapDownloader, mapId, accessToken, mapRegion, minimumZ, maximumZ, true, true);
+        beginDownloadingMapID(mapDownloader, userId, mapId, accessToken, mapRegion, minimumZ, maximumZ, true, true);
     }
 
-    private void beginDownloadingMapID(final MapDownloader mapDownloader, final String mapId, final String accessToken, DPMap.VisibleMapArea mapRegion, int
+    private void beginDownloadingMapID(final MapDownloader mapDownloader, final String userId, final String mapId, final String accessToken, DPMap.VisibleMapArea mapRegion, int
         minimumZ, int maximumZ, boolean includeMetadata,
                                       boolean includeMarkers) {
 
@@ -76,11 +82,11 @@ public class MapboxTileProviderManager extends TileProviderManager {
         String dataName = "features.json";    // Only using API V4 for now
 
         // Include URLs for the metadata and markers json if applicable
-        if (includeMetadata) {
+        if (false) {
             urls.add(String.format(Locale.US, MapboxUtils.MAPBOX_BASE_URL_V4 + "%s.json?secure&access_token=%s",
                 mapId, accessToken));
         }
-        if (includeMarkers) {
+        if (false) {
             urls.add(String.format(Locale.US, MapboxUtils.MAPBOX_BASE_URL_V4 + "%s/%s?access_token=%s", mapId,
                 dataName, accessToken));
         }

--- a/Android/src/org/droidplanner/android/maps/providers/google_map/tiles/mapbox/MapboxTileProviderManager.java
+++ b/Android/src/org/droidplanner/android/maps/providers/google_map/tiles/mapbox/MapboxTileProviderManager.java
@@ -123,7 +123,7 @@ public class MapboxTileProviderManager extends TileProviderManager {
             maxY = Double.valueOf(Math.floor((1.0 - (Math.log(Math.tan(minLat * Math.PI / 180.0) + 1.0 / Math.cos(minLat * Math.PI / 180.0)) / Math.PI)) / 2.0 * tilesPerSide)).intValue();
             for (int x = minX; x <= maxX; x++) {
                 for (int y = minY; y <= maxY; y++) {
-                    urls.add(MapboxUtils.getMapTileURL(mapId, accessToken, zoom, x, y));
+                    urls.add(MapboxUtils.getMapTileURL(userId, mapId, accessToken, zoom, x, y));
                 }
             }
         }

--- a/Android/src/org/droidplanner/android/maps/providers/google_map/tiles/mapbox/MapboxUtils.java
+++ b/Android/src/org/droidplanner/android/maps/providers/google_map/tiles/mapbox/MapboxUtils.java
@@ -30,13 +30,13 @@ public class MapboxUtils {
                 userId, mapID, zoom, x, y, "@2x", accessToken);
     }
 
-    public static int fetchReferenceTileUrl(Context context, String mapId, String accessToken){
+    public static int fetchReferenceTileUrl(Context context, String userId, String mapId, String accessToken){
         if(!NetworkUtils.isNetworkAvailable(context)){
             Timber.d("Network is not available. Aborting reference tile fetching.");
             return -1;
         }
 
-        final String referenceUrl = getMapTileURL(mapId, accessToken, 0, 0, 0);
+        final String referenceUrl = getMapTileURL(userId, mapId, accessToken, 0, 0, 0);
 
         HttpURLConnection conn = null;
         try{

--- a/Android/src/org/droidplanner/android/maps/providers/google_map/tiles/mapbox/MapboxUtils.java
+++ b/Android/src/org/droidplanner/android/maps/providers/google_map/tiles/mapbox/MapboxUtils.java
@@ -25,9 +25,9 @@ public class MapboxUtils {
 
     public static final String MAPBOX_BASE_URL_V4 = "https://a.tiles.mapbox.com/v4/";
 
-    public static String getMapTileURL(String mapID, String accessToken, int zoom, int x, int y) {
-        return String.format(Locale.US, "https://a.tiles.mapbox.com/v4/%s/%d/%d/%d%s.%s?access_token=%s",
-                mapID, zoom, x, y, "@2x", "png", accessToken);
+    public static String getMapTileURL(String userId, String mapID, String accessToken, int zoom, int x, int y) {
+        return String.format(Locale.US, "https://api.mapbox.com/styles/v1/%s/%s/tiles/%d/%d/%d%s?access_token=%s",
+                userId, mapID, zoom, x, y, "@2x", accessToken);
     }
 
     public static int fetchReferenceTileUrl(Context context, String mapId, String accessToken){

--- a/Android/src/org/droidplanner/android/maps/providers/google_map/tiles/mapbox/OfflineTileProvider.java
+++ b/Android/src/org/droidplanner/android/maps/providers/google_map/tiles/mapbox/OfflineTileProvider.java
@@ -15,12 +15,14 @@ public class OfflineTileProvider implements TileProvider {
     private static final String TAG = OfflineTileProvider.class.getSimpleName();
 
     private final Context context;
+    private final String mapboxUserId;
     private final String mapboxId;
     private final String mapboxAccessToken;
     private final int maxZoomLevel;
 
-    public OfflineTileProvider(Context context, String mapboxId, String mapboxAccessToken, int maxZoomLevel) {
+    public OfflineTileProvider(Context context, String mapboxUserId, String mapboxId, String mapboxAccessToken, int maxZoomLevel) {
         this.context = context;
+        this.mapboxUserId = mapboxUserId;
         this.mapboxId = mapboxId;
         this.mapboxAccessToken = mapboxAccessToken;
         this.maxZoomLevel = maxZoomLevel;
@@ -32,7 +34,7 @@ public class OfflineTileProvider implements TileProvider {
             return TileProvider.NO_TILE;
         }
 
-        final String tileUri = MapboxUtils.getMapTileURL(mapboxId, mapboxAccessToken, zoom, x, y);
+        final String tileUri = MapboxUtils.getMapTileURL(mapboxUserId, mapboxId, mapboxAccessToken, zoom, x, y);
         byte[] data = DatabaseState.getOfflineDatabaseHandlerForMapId(context, mapboxId).dataForURL(tileUri);
         if (data == null || data.length == 0)
             return TileProvider.NO_TILE;


### PR DESCRIPTION
Mapbox integration was faulty after Mapbox discontinued their "Projects" and stopped developing Mapbox Classic. New solution for map designers (or anyone interested in creating a free account to use their services) is Mapbox Studio. Tower threw error messages of incorrect credentials, but could partly display mapbox maps if <userid>.<mapId> was entered into Tower Map ID field.

This pull request solves the error messages by switching out the API to retrieve raster tiles from styles. API documented here: https://docs.mapbox.com/api/maps/#retrieve-raster-tiles-from-styles
To support this API, a field to capture the users mapbox user name is introduced. In addition, the mapId field is re-used to enter the ID of the style rather than the mapId. Two API calls to retrieve additional "markers" and "polygons" are disabled since I had problems to support that and saw no obvious use case. But if these objects are included into their mapbox style, they will be retrieved by Tower anyway. In addition, the leak canary is disabled in this PR.

Solution works almost flawless. One problem remains: When user select the flight data screen, the style tiles are not shown. Seems to be caused in DroneMap.java, where use case start flight data only trigger function onStart(), while use cases starting editor/history/"flip orientation" all have a preceding call to onCreateView() upfront of onStart(). The workaround in flight data screen: Rotate device (horisontal <=> portrait), and mapbox tiles becomes visible again.